### PR TITLE
fix: add version command and arg

### DIFF
--- a/Sources/Container-Compose/Application.swift
+++ b/Sources/Container-Compose/Application.swift
@@ -12,7 +12,7 @@ import ArgumentParser
 struct Main: AsyncParsableCommand {
     private static let commandName: String = "container-compose"
     private static let version: String = "v0.5.1"
-    public static var versionString: String {
+    static var versionString: String {
         "\(commandName) version \(version)"
     }
     static let configuration: CommandConfiguration = .init(

--- a/Sources/Container-Compose/Commands/Version.swift
+++ b/Sources/Container-Compose/Commands/Version.swift
@@ -24,15 +24,14 @@
 import ArgumentParser
 import Foundation
 
-internal struct Version: ParsableCommand {
-    public init() {}
+struct Version: ParsableCommand {
 
-    public static let configuration: CommandConfiguration = .init(
+    static let configuration: CommandConfiguration = .init(
         commandName: "version",
         abstract: "Display the version information"
     )
 
-    public func run() {
+    func run() {
         print("\(Main.versionString)")
     }
 }


### PR DESCRIPTION
Closes #8 

Adds a version command to the tool.

It would need to be manually updated in Application.swift before release. 