### PR TITLE
Fix: Platform specific Image Pulling

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -332,7 +332,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         } else if let img = service.image {
             // Use specified image if no build config
             // Pull image if necessary
-            try await pullImage(img, platform: service.container_name)
+            try await pullImage(img, platform: service.platform)
             imageToRun = img
         } else {
             // Should not happen due to Service init validation, but as a fallback


### PR DESCRIPTION
Closes #6 by fixing a mistake where the wrong property was passed in for the `pullImage` function.