### PR TITLE
Enable Port Binding/Mapping

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -431,14 +431,13 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             runCommandArgs.append("\(key)=\(value)")
         }
 
-        // REMOVED: Port mappings (-p) are not supported by `container run`
-        // if let ports = service.ports {
-        //     for port in ports {
-        //         let resolvedPort = resolveVariable(port, with: envVarsFromFile)
-        //         runCommandArgs.append("-p")
-        //         runCommandArgs.append(resolvedPort)
-        //     }
-        // }
+         if let ports = service.ports {
+             for port in ports {
+                 let resolvedPort = resolveVariable(port, with: environmentVariables)
+                 runCommandArgs.append("-p")
+                 runCommandArgs.append("0.0.0.0:\(resolvedPort)")
+             }
+         }
 
         // Connect to specified networks
         if let serviceNetworks = service.networks {
@@ -573,7 +572,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             commands.append(contentsOf: ["--platform", platform])
         }
 
-        var imagePull = try Application.ImagePull.parse(commands + global.passThroughCommands())
+        let imagePull = try Application.ImagePull.parse(commands + global.passThroughCommands())
         try await imagePull.run()
     }
 


### PR DESCRIPTION
Closes #18 

With Apple container 0.3, port mapping was re-introduced to their tool. Now I am finally re-enabling it in here.

One note is that it binds to 0.0.0.0 for compatibility reasons, so be careful when exposing to the internet. 