### PR TITLE
added information about what command is being run for easier debugging

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -550,6 +550,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
 
             print("\nStarting service: \(serviceName)")
             print("Starting \(serviceName)")
+            print("Running: container run \(runCommandArgs.joined(separator: " "))")
             print("----------------------------------------\n")
             let _ = try await streamCommand("container", args: ["run"] + runCommandArgs, onStdout: handleOutput, onStderr: handleOutput)
         }
@@ -633,6 +634,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         let buildCommand = try Application.BuildCommand.parse(commands)
         print("\n----------------------------------------")
         print("Building image for service: \(serviceName) (Tag: \(imageToRun))")
+        print("Running: container build \(commands.joined(separator: " "))")
         try buildCommand.validate()
         try await buildCommand.run()
         print("Image build for \(serviceName) completed.")


### PR DESCRIPTION
When debugging problems with apple/container or this package, there was missing information about what is actually happening.