### PR TITLE
fixed wrong named volume destination

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -691,9 +691,6 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             let volumeUrl = URL.homeDirectory.appending(path: ".containers/Volumes/\(projectName)/\(source)")
             let volumePath = volumeUrl.path(percentEncoded: false)
 
-            let destinationUrl = URL(fileURLWithPath: destination).deletingLastPathComponent()
-            let destinationPath = destinationUrl.path(percentEncoded: false)
-
             print(
                 "Warning: Volume source '\(source)' appears to be a named volume reference. The 'container' tool does not support named volume references in 'container run -v' command. Linking to \(volumePath) instead."
             )
@@ -702,7 +699,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             // Host path exists and is a directory, add the volume
             runCommandArgs.append("-v")
             // Reconstruct the volume string without mode, ensuring it's source:destination
-            runCommandArgs.append("\(volumePath):\(destinationPath)")  // Use original source for command argument
+            runCommandArgs.append("\(volumePath):\(destination)")  // Use original source for command argument
         }
 
         return runCommandArgs


### PR DESCRIPTION
**Description**: When using named volumes with a destination path, `container-compose` mounts to the wrong path.

**Docker Compose Configuration**:
```yaml
volumes:
    - elasticsearch-data:/usr/share/elasticsearch/data
```

**Expected Behavior**: Mount volume to `/usr/share/elasticsearch/data`

**Actual Behavior**: Mounts to `/usr/share/elasticsearch/` (missing `/data` suffix)