### PR TITLE
Properly handle the -f flag to be the primary file when used by up or down

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeDown.swift
+++ b/Sources/Container-Compose/Commands/ComposeDown.swift
@@ -47,9 +47,11 @@ public struct ComposeDown: AsyncParsableCommand {
     var composeFilename: String? = nil
     private var composePath: String {
         let filename = composeFilename ?? "compose.yml"
-        // Handle absolute paths
-        if filename.hasPrefix("/") || filename.hasPrefix("~") {
+        // Handle absolute paths and tilde expansion
+        if filename.hasPrefix("/") {
             return filename
+        } else if filename.hasPrefix("~") {
+            return NSString(string: filename).expandingTildeInPath
         } else {
             return "\(cwd)/\(filename)"
         }
@@ -74,10 +76,7 @@ public struct ComposeDown: AsyncParsableCommand {
                     break
                 }
             }
-            // If no file was found, default to compose.yml (will fail later with proper error)
-            if composeFilename == nil {
-                composeFilename = "compose.yml"
-            }
+            // No need to set composeFilename = "compose.yml" here; composePath already handles the nil case
         }
 
         // Read docker-compose.yml content

--- a/Sources/Container-Compose/Commands/ComposeDown.swift
+++ b/Sources/Container-Compose/Commands/ComposeDown.swift
@@ -76,7 +76,6 @@ public struct ComposeDown: AsyncParsableCommand {
                     break
                 }
             }
-            // No need to set composeFilename = "compose.yml" here; composePath already handles the nil case
         }
 
         // Read docker-compose.yml content

--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -99,7 +99,6 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
                     break
                 }
             }
-            // No need to set composeFilename = "compose.yml" here; composePath already handles the nil case
         }
 
         // Read compose.yml content
@@ -331,7 +330,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
                 return
             }
             let commands = [actualNetworkName]
-            
+
             var networkCreate = try Application.NetworkCreate.parse(commands + global.passThroughCommands())
 
             try await networkCreate.run()
@@ -344,7 +343,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         guard let projectName else { throw ComposeError.invalidProjectName }
 
         var imageToRun: String
-        
+
         var runCommandArgs: [String] = []
 
         // Handle 'build' configuration
@@ -359,7 +358,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             // Should not happen due to Service init validation, but as a fallback
             throw ComposeError.imageNotFound(serviceName)
         }
-        
+
         // Set Run Platform
         if let platform = service.platform {
             runCommandArgs.append(contentsOf: ["--platform", "\(platform)"])
@@ -582,11 +581,11 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         }
 
         print("Pulling Image \(imageName)...")
-        
+
         var commands = [
             imageName
         ]
-        
+
         if let platform {
             commands.append(contentsOf: ["--platform", platform])
         }
@@ -613,30 +612,30 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
 
         // Build command arguments
         var commands = ["\(self.cwd)/\(buildConfig.context)"]
-        
+
         // Add build arguments
         for (key, value) in buildConfig.args ?? [:] {
             commands.append(contentsOf: ["--build-arg", "\(key)=\(resolveVariable(value, with: environmentVariables))"])
         }
-        
+
         // Add Dockerfile path
         commands.append(contentsOf: ["--file", "\(self.cwd)/\(buildConfig.dockerfile ?? "Dockerfile")"])
-        
+
         // Add caching options
         if noCache {
             commands.append("--no-cache")
         }
-        
+
         // Add OS/Arch
         let split = service.platform?.split(separator: "/")
         let os = String(split?.first ?? "linux")
         let arch = String(((split ?? []).count >= 1 ? split?.last : nil) ?? "arm64")
         commands.append(contentsOf: ["--os", os])
         commands.append(contentsOf: ["--arch", arch])
-        
+
         // Add image name
         commands.append(contentsOf: ["--tag", imageToRun])
-        
+
         // Add CPU & Memory
         let cpuCount = Int64(service.deploy?.resources?.limits?.cpus ?? "2") ?? 2
         let memoryLimit = service.deploy?.resources?.limits?.memory ?? "2048MB"

--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -49,9 +49,11 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
     var composeFilename: String? = nil
     private var composePath: String {
         let filename = composeFilename ?? "compose.yml"
-        // Handle absolute paths
-        if filename.hasPrefix("/") || filename.hasPrefix("~") {
+        // Handle absolute paths and tilde expansion
+        if filename.hasPrefix("/") {
             return filename
+        } else if filename.hasPrefix("~") {
+            return NSString(string: filename).expandingTildeInPath
         } else {
             return "\(cwd)/\(filename)"
         }
@@ -97,10 +99,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
                     break
                 }
             }
-            // If no file was found, default to compose.yml (will fail later with proper error)
-            if composeFilename == nil {
-                composeFilename = "compose.yml"
-            }
+            // No need to set composeFilename = "compose.yml" here; composePath already handles the nil case
         }
 
         // Read compose.yml content


### PR DESCRIPTION
As mentioned in #33, if you have one of the "key" compose file names, `up` and `down` will choose that file, even if you've provided a file via the `-f` flag. This changes the logic to choose and handle the `-f` flag appropriately.

With Swift not being my primary language, I've worked with Claude Code to build this PR. 