### PR TITLE
Adding support for `build: context`

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -598,10 +598,12 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             return imageToRun
         }
 
-        // Resolve context path (handle absolute paths)
+        // Resolve context path (handle absolute paths and tilde expansion)
         let contextPath: String
-        if buildConfig.context.hasPrefix("/") || buildConfig.context.hasPrefix("~") {
+        if buildConfig.context.hasPrefix("/") {
             contextPath = buildConfig.context
+        } else if buildConfig.context.hasPrefix("~") {
+            contextPath = NSString(string: buildConfig.context).expandingTildeInPath
         } else {
             contextPath = "\(self.cwd)/\(buildConfig.context)"
         }


### PR DESCRIPTION
As mentioned in #34, only a small portion of the `build` syntax was supported, which didn't handle the `context` and `dockerfile` (and other options). This PR handles the additional capabilities (which has enabled my default compose file to work).

Swift is not my primary language, so I was assisted in building with Claude Code.