### PR TITLE
feat: Support for --cpus and --memory resource options

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -489,6 +489,14 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             runCommandArgs.append("--read-only")
         }
 
+        // Add resource limits
+        if let cpus = service.deploy?.resources?.limits?.cpus {
+            runCommandArgs.append(contentsOf: ["--cpus", cpus])
+        }
+        if let memory = service.deploy?.resources?.limits?.memory {
+            runCommandArgs.append(contentsOf: ["--memory", memory])
+        }
+
         // Handle service-level configs (note: still only parsing/logging, not attaching)
         if let serviceConfigs = service.configs {
             print(

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -378,6 +378,27 @@ struct DockerComposeParsingTests {
         
         #expect(compose.services["app"]??.platform == "linux/amd64")
     }
+
+    @Test("Parse deploy resources limits (cpus and memory)")
+    func parseComposeWithDeployResources() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: alpine:latest
+            deploy:
+              resources:
+                limits:
+                  cpus: "0.5"
+                  memory: "512M"
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+
+        #expect(compose.services["app"]??.deploy?.resources?.limits?.cpus == "0.5")
+        #expect(compose.services["app"]??.deploy?.resources?.limits?.memory == "512M")
+    }
     
     @Test("Service must have image or build - should fail without either")
     func serviceRequiresImageOrBuild() throws {


### PR DESCRIPTION
## Summary
- Adds support for `--cpus` and `--memory` container resource limit flags during `compose up`
- Reads values from `deploy.resources.limits.cpus` and `deploy.resources.limits.memory` in the compose file and passes them to the container run command

## Test plan
- [ ] Run `compose up` with a service that has `deploy.resources.limits.cpus` and `deploy.resources.limits.memory` set
- [ ] Verify the container is created with the correct resource constraints
- [ ] Run `compose up` without resource limits and verify no extra flags are passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)