### PR TITLE
fix(parsing): support map form of depends_on with condition syntax

### DIFF
--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -192,8 +192,14 @@ public struct Service: Codable, Hashable {
         
         if let dependsOnString = try? container.decodeIfPresent(String.self, forKey: .depends_on) {
             depends_on = [dependsOnString]
+        } else if let dependsOnArray = try? container.decodeIfPresent([String].self, forKey: .depends_on) {
+            depends_on = dependsOnArray
+        } else if let dependsOnMap = try? container.decodeIfPresent([String: [String: String]].self, forKey: .depends_on) {
+            // Map form: depends_on: { db: { condition: service_healthy } }
+            // Preserve dependency order; conditions are not applicable to Apple Container.
+            depends_on = dependsOnMap.keys.sorted()
         } else {
-            depends_on = try container.decodeIfPresent([String].self, forKey: .depends_on)
+            depends_on = nil
         }
         user = try container.decodeIfPresent(String.self, forKey: .user)
 

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -180,6 +180,32 @@ struct DockerComposeParsingTests {
         #expect(compose.services["web"]??.depends_on?.contains("db") == true)
     }
     
+    @Test("Parse compose with depends_on map form (condition syntax)")
+    func parseComposeWithDependenciesMapForm() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          web:
+            image: nginx:latest
+            depends_on:
+              db:
+                condition: service_healthy
+              cache:
+                condition: service_started
+          db:
+            image: postgres:14
+          cache:
+            image: redis:7
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+
+        #expect(compose.services["web"]??.depends_on?.contains("db") == true)
+        #expect(compose.services["web"]??.depends_on?.contains("cache") == true)
+        #expect(compose.services["web"]??.depends_on?.count == 2)
+    }
+
     @Test("Parse compose with build context")
     func parseComposeWithBuild() throws {
         let yaml = """


### PR DESCRIPTION
## Problem

`container-compose` throws a `typeMismatch` error on any compose file that uses the map form of `depends_on`:

```yaml
depends_on:
  db:
    condition: service_healthy
```

This is valid Docker Compose spec (v2+) and is common in real-world stacks (Windmill, Keycloak, Traefik setups, etc). Only the list form worked:

```yaml
depends_on:
  - db
```

## Fix

In `Service.swift`, after failing to decode as `String` or `[String]`, attempt to decode as `[String: [String: String]]` and extract the map keys as the dependency list. Conditions are dropped since Apple Container has no equivalent orchestration-layer concept.

```swift
} else if let dependsOnMap = try? container.decodeIfPresent([String: [String: String]].self, forKey: .depends_on) {
    // Map form: depends_on: { db: { condition: service_healthy } }
    // Preserve dependency order; conditions are not applicable to Apple Container.
    depends_on = dependsOnMap.keys.sorted()
}
```

## Tests

Added `parseComposeWithDependenciesMapForm` covering:
- Two dependencies with different condition values (`service_healthy`, `service_started`)
- Both service names extracted correctly
- Count assertion

Both new and existing `depends_on` tests pass.

## Verified against

Windmill CE `docker-compose.yml` — previously failed at parse, now reaches image pull stage.