### PR TITLE
fix(build): resolve dockerfile path relative to build context, not compose dir

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeBuild.swift
+++ b/Sources/Container-Compose/Commands/ComposeBuild.swift
@@ -131,14 +131,17 @@ public struct ComposeBuild: AsyncParsableCommand, @unchecked Sendable {
     ) async throws {
         let imageTag = service.image ?? "\(serviceName):latest"
 
-        var commands = [URL(fileURLWithPath: buildConfig.context, relativeTo: URL(fileURLWithPath: composeDirectory)).path]
+        // Per Compose spec: `context` is relative to the compose file's directory,
+        // and `dockerfile` is relative to the resolved `context` (not the compose dir).
+        let contextURL = URL(fileURLWithPath: buildConfig.context, relativeTo: URL(fileURLWithPath: composeDirectory))
+        var commands = [contextURL.path]
 
         for (key, value) in buildConfig.args ?? [:] {
             commands.append(contentsOf: ["--build-arg", "\(key)=\(resolveVariable(value, with: environmentVariables))"])
         }
 
         commands.append(contentsOf: [
-            "--file", URL(fileURLWithPath: buildConfig.dockerfile ?? "Dockerfile", relativeTo: URL(fileURLWithPath: composeDirectory)).path,
+            "--file", URL(fileURLWithPath: buildConfig.dockerfile ?? "Dockerfile", relativeTo: contextURL).path,
             "--tag", imageTag,
         ])
 

--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -628,8 +628,10 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             return imageToRun
         }
 
-        // Build command arguments
-        var commands = [URL(fileURLWithPath: buildConfig.context, relativeTo: URL(fileURLWithPath: composeDirectory)).path]
+        // Per Compose spec: `context` is relative to the compose file's directory,
+        // and `dockerfile` is relative to the resolved `context` (not the compose dir).
+        let contextURL = URL(fileURLWithPath: buildConfig.context, relativeTo: URL(fileURLWithPath: composeDirectory))
+        var commands = [contextURL.path]
 
         // Add build arguments
         for (key, value) in buildConfig.args ?? [:] {
@@ -637,7 +639,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         }
 
         // Add Dockerfile path
-        commands.append(contentsOf: ["--file", URL(fileURLWithPath: buildConfig.dockerfile ?? "Dockerfile", relativeTo: URL(fileURLWithPath: composeDirectory)).path])
+        commands.append(contentsOf: ["--file", URL(fileURLWithPath: buildConfig.dockerfile ?? "Dockerfile", relativeTo: contextURL).path])
         
         // Add caching options
         if noCache {

--- a/Tests/Container-Compose-DynamicTests/ComposeBuildTests.swift
+++ b/Tests/Container-Compose-DynamicTests/ComposeBuildTests.swift
@@ -155,4 +155,89 @@ struct ComposeBuildTests {
         // Should complete without throwing even though nothing is built
         try await composeBuild.run()
     }
+
+    // Per Compose spec: `dockerfile:` is resolved relative to the build `context:`,
+    // not relative to the compose file's directory. See issue #34, PR #37.
+    @Test("Build with subdirectory context resolves default Dockerfile inside the context")
+    func buildContextSubdirResolvesDockerfileInsideContext() async throws {
+        let yaml = """
+        services:
+          ctxsub:
+            build:
+              context: ./sub
+        """
+
+        let project = try DockerComposeYamlFiles.copyYamlToTemporaryLocation(yaml: yaml)
+
+        // Dockerfile lives inside the context dir, NOT next to the compose file.
+        let subDir = project.base.appending(path: "sub")
+        try FileManager.default.createDirectory(at: subDir, withIntermediateDirectories: true)
+        try "FROM alpine:latest"
+            .write(to: subDir.appending(path: "Dockerfile"), atomically: false, encoding: .utf8)
+
+        var composeBuild = try ComposeBuild.parse([
+            "--cwd", project.base.path(percentEncoded: false),
+        ])
+        try await composeBuild.run()
+
+        #expect(try await imageExists(named: "ctxsub:latest"))
+    }
+
+    // Same intent as above but with a sibling/parent-relative context, which is
+    // the shape every real-world monorepo compose file uses.
+    @Test("Build with parent-relative context resolves Dockerfile in the sibling dir")
+    func buildContextParentRelativeResolvesDockerfileInContext() async throws {
+        let yaml = """
+        services:
+          ctxsibling:
+            build:
+              context: ../sub
+        """
+
+        let project = try DockerComposeYamlFiles.copyYamlToTemporaryLocation(yaml: yaml)
+
+        // Move the compose file one level deeper so `../sub` is meaningful.
+        let composeDir = project.base.appending(path: "compose-dir")
+        try FileManager.default.createDirectory(at: composeDir, withIntermediateDirectories: true)
+        let movedCompose = composeDir.appending(path: "docker-compose.yaml")
+        try FileManager.default.moveItem(at: project.url, to: movedCompose)
+
+        let subDir = project.base.appending(path: "sub")
+        try FileManager.default.createDirectory(at: subDir, withIntermediateDirectories: true)
+        try "FROM alpine:latest"
+            .write(to: subDir.appending(path: "Dockerfile"), atomically: false, encoding: .utf8)
+
+        var composeBuild = try ComposeBuild.parse([
+            "--cwd", composeDir.path(percentEncoded: false),
+        ])
+        try await composeBuild.run()
+
+        #expect(try await imageExists(named: "ctxsibling:latest"))
+    }
+
+    // Custom dockerfile name, still must be resolved relative to context.
+    @Test("Build with custom dockerfile filename resolves it inside the context")
+    func buildContextCustomDockerfileResolvesInsideContext() async throws {
+        let yaml = """
+        services:
+          ctxcustom:
+            build:
+              context: ./build
+              dockerfile: Dockerfile.dev
+        """
+
+        let project = try DockerComposeYamlFiles.copyYamlToTemporaryLocation(yaml: yaml)
+
+        let buildDir = project.base.appending(path: "build")
+        try FileManager.default.createDirectory(at: buildDir, withIntermediateDirectories: true)
+        try "FROM alpine:latest"
+            .write(to: buildDir.appending(path: "Dockerfile.dev"), atomically: false, encoding: .utf8)
+
+        var composeBuild = try ComposeBuild.parse([
+            "--cwd", project.base.path(percentEncoded: false),
+        ])
+        try await composeBuild.run()
+
+        #expect(try await imageExists(named: "ctxcustom:latest"))
+    }
 }


### PR DESCRIPTION
Per the Compose spec, `services.<svc>.build.dockerfile` is resolved relative to the resolved `build.context`, not to the directory of the compose file. Current `main` resolves both against `composeDirectory`, so any layout that puts the Dockerfile inside a subdirectory of the context (or uses the standard `context: ../foo` monorepo shape) fails:

```
$ container-compose build -f /tmp/ctx/compose-dir/test.yml
Error: dockerfile does not exist /tmp/ctx/compose-dir/Dockerfile
# (the Dockerfile is at /tmp/ctx/sub/Dockerfile, where context: ../sub points)
```

Changes:
- `ComposeBuild.swift`, `ComposeUp.swift`: resolve `dockerfile` against the resolved `contextURL` rather than `composeDirectory`. `context` itself is still resolved against `composeDirectory`, which was already correct.
- Adds three dynamic tests in `ComposeBuildTests.swift` covering: subdirectory context with default Dockerfile, parent-relative context (`../sub`), and custom dockerfile filename (`Dockerfile.dev`) inside the context.

All three tests fail on `main` with the "dockerfile does not exist" error and pass with this change. The 6 unrelated pre-existing test failures on `main` are unchanged.

Refs #34, supersedes #37.