### PR TITLE
fix(up): match locally-built multi-path images so pull is skipped

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -594,7 +594,19 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
 
     private func pullImage(_ imageName: String, platform: String?) async throws {
         let imageList = try await ClientImage.list()
-        guard !imageList.contains(where: { $0.description.reference.components(separatedBy: "/").last == imageName }) else {
+        // An image is considered already-local if any of:
+        //   - the stored reference matches `imageName` exactly (multi-path local builds, e.g. `myorg/foo:local`)
+        //   - the stored reference is `imageName` with a registry prefix (`docker.io/library/nginx:latest`
+        //     when the user wrote `nginx:latest` or `library/nginx:latest`)
+        //   - the last `/`-separated component of the stored reference matches `imageName`
+        //     (legacy fallback for short references like `alpine:latest`)
+        let exists = imageList.contains { ref in
+            let stored = ref.description.reference
+            return stored == imageName
+                || stored.hasSuffix("/\(imageName)")
+                || stored.components(separatedBy: "/").last == imageName
+        }
+        guard !exists else {
             return
         }
 

--- a/Tests/Container-Compose-DynamicTests/ComposeUpTests.swift
+++ b/Tests/Container-Compose-DynamicTests/ComposeUpTests.swift
@@ -323,6 +323,57 @@ struct ComposeUpTests {
         try? await stopInstance(location: project.base)
     }
     
+    // A locally-built image whose reference contains a `/` (e.g. `myorg/foo:local`)
+    // must not trigger a registry pull when referenced from a compose file.
+    // Regression test for the issue where `pullImage`'s match check only compared
+    // the last `/`-separated path component of the stored image reference against
+    // the requested image name, missing exact and registry-prefixed matches.
+    @Test("Compose up with a locally-built multi-path image does not attempt a registry pull")
+    func composeUpUsesLocalMultiPathImage() async throws {
+        let imageRef = "containercompose-localpullttest/foo:local"
+
+        // Step 1: build the image locally with a multi-path tag.
+        let buildYaml = """
+        services:
+          foo:
+            image: \(imageRef)
+            build:
+              context: .
+              dockerfile: Dockerfile
+        """
+        let buildProject = try DockerComposeYamlFiles.copyYamlToTemporaryLocation(yaml: buildYaml)
+        let dockerfilePath = buildProject.base.appending(path: "Dockerfile").path(percentEncoded: false)
+        try "FROM alpine:latest".write(toFile: dockerfilePath, atomically: false, encoding: .utf8)
+
+        var composeBuild = try ComposeBuild.parse([
+            "--cwd", buildProject.base.path(percentEncoded: false),
+        ])
+        try await composeBuild.run()
+
+        // Step 2: in a different project dir, run `up` referencing that image by name.
+        // On the bug, `pullImage` does not recognize the local image and tries to
+        // pull `containercompose-localpullttest/foo:local` from the default registry,
+        // which fails 401.
+        let upYaml = """
+        services:
+          app:
+            image: \(imageRef)
+            command: ["sleep", "30"]
+        """
+        let upProject = try DockerComposeYamlFiles.copyYamlToTemporaryLocation(yaml: upYaml)
+
+        var composeUp = try ComposeUp.parse([
+            "-d", "--cwd", upProject.base.path(percentEncoded: false),
+        ])
+        try await composeUp.run()
+
+        let containers = try await ContainerClient().list()
+            .filter { $0.configuration.id == "\(upProject.name)-app" }
+        #expect(containers.count == 1)
+
+        try? await stopInstance(location: upProject.base)
+    }
+
     enum Errors: Error {
         case containerNotFound
     }


### PR DESCRIPTION
`pullImage` only compared the last `/`-separated path component of each stored image reference against the requested image name. That works for registry-prefixed locals (`docker.io/library/nginx:latest` ↔ user typed `nginx:latest`), but misses two real cases:

- A locally-built image with a multi-path tag like `myorg/foo:local` matches itself only via exact reference, never via a path-component last-segment compare.
- The same flow but reversed: user types the registry-prefixed form and the local store has the short form.

Both fall into the registry-fetch path and hit `401 Unauthorized` from the default registry, even though the image is in the local store.

The match now also accepts:
- exact reference equality
- the stored reference being `<registry>/<imageName>` (registry-prefixed form of the requested name)

The existing last-segment match is preserved as a fallback so single-segment refs (`alpine:latest`) keep working.

Adds a dynamic test in `ComposeUpTests` that builds an image with a multi-path tag and then runs `up` referencing it. Fails on `main` with the 401, passes with this change. The 6 unrelated pre-existing failures on `main` are unchanged.

Refs #76.