### PR TITLE
Expose core library target and expand Compose parser coverage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,10 @@ import PackageDescription
 let package = Package(
     name: "Container-Compose",
     platforms: [.macOS(.v15)],
+    products: [
+        .library(name: "ContainerComposeCore", targets: ["ContainerComposeCore"]),
+        .executable(name: "container-compose", targets: ["Container-Compose"]),
+    ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.1"),
         .package(url: "https://github.com/mcrich23/container", branch: "add-command-option-group-function-macro"),

--- a/Sources/Container-Compose/Codable Structs/Network.swift
+++ b/Sources/Container-Compose/Codable Structs/Network.swift
@@ -40,10 +40,12 @@ public struct Network: Codable {
     public let name: String?
     /// Indicates if the network is external (pre-existing)
     public let external: ExternalNetwork?
+    /// IPAM configuration for subnets and related allocation options.
+    public let ipam: NetworkIPAM?
 
     /// Updated CodingKeys to map 'internal' from YAML to 'isInternal' Swift property
     enum CodingKeys: String, CodingKey {
-        case driver, driver_opts, attachable, enable_ipv6, isInternal = "internal", labels, name, external
+        case driver, driver_opts, attachable, enable_ipv6, isInternal = "internal", labels, name, external, ipam
     }
 
     /// Custom initializer to handle `external: true` (boolean) or `external: { name: "my_net" }` (object).
@@ -56,6 +58,7 @@ public struct Network: Codable {
         isInternal = try container.decodeIfPresent(Bool.self, forKey: .isInternal) // Use isInternal here
         labels = try container.decodeIfPresent([String: String].self, forKey: .labels)
         name = try container.decodeIfPresent(String.self, forKey: .name)
+        ipam = try container.decodeIfPresent(NetworkIPAM.self, forKey: .ipam)
 
         if let externalBool = try? container.decodeIfPresent(Bool.self, forKey: .external) {
             external = ExternalNetwork(isExternal: externalBool, name: nil)
@@ -64,5 +67,35 @@ public struct Network: Codable {
         } else {
             external = nil
         }
+    }
+
+}
+
+public struct NetworkIPAM: Codable {
+    public let driver: String?
+    public let config: [NetworkIPAMConfig]?
+    public let options: [String: String]?
+
+    public var ipv4Subnet: String? {
+        config?.compactMap(\.subnet).first { !$0.contains(":") }
+    }
+
+    public var ipv6Subnet: String? {
+        config?.compactMap(\.subnet).first { $0.contains(":") }
+    }
+
+}
+
+public struct NetworkIPAMConfig: Codable {
+    public let subnet: String?
+    public let ipRange: String?
+    public let gateway: String?
+    public let auxAddresses: [String: String]?
+
+    enum CodingKeys: String, CodingKey {
+        case subnet
+        case ipRange = "ip_range"
+        case gateway
+        case auxAddresses = "aux_addresses"
     }
 }

--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -50,6 +50,9 @@ public struct Service: Codable, Hashable {
     /// List of .env files to load environment variables from
     public let env_file: [String]?
 
+    /// Detailed env file entries keyed by list order
+    public let envFileConfigurations: [ServiceEnvFile]?
+
     /// Port mappings (e.g., "hostPort:containerPort")
     public let ports: [String]?
 
@@ -59,6 +62,9 @@ public struct Service: Codable, Hashable {
     /// Services this service depends on (for startup order)
     public let depends_on: [String]?
 
+    /// Detailed dependency options keyed by service name
+    public let dependencyConfigurations: [String: ServiceDependency]?
+
     /// User or UID to run the container as
     public let user: String?
 
@@ -67,6 +73,9 @@ public struct Service: Codable, Hashable {
 
     /// List of networks the service will connect to
     public let networks: [String]?
+
+    /// Service-level network options keyed by network name
+    public let networkConfigurations: [String: ServiceNetwork]?
 
     /// Container hostname
     public let hostname: String?
@@ -80,11 +89,32 @@ public struct Service: Codable, Hashable {
     /// Mount container's root filesystem as read-only
     public let read_only: Bool?
 
+    /// Mount tmpfs paths inside the container
+    public let tmpfs: [String]?
+
+    /// Linux capabilities to add
+    public let cap_add: [String]?
+
+    /// Linux capabilities to drop
+    public let cap_drop: [String]?
+
+    /// Container ulimit settings
+    public let ulimits: [String: ServiceUlimit]?
+
+    /// Run an init process as PID 1
+    public let initProcess: Bool?
+
+    /// Security options such as no-new-privileges
+    public let security_opt: [String]?
+
     /// Working directory inside the container
     public let working_dir: String?
 
     /// Platform architecture for the service
     public let platform: String?
+
+    /// Profiles that activate this service
+    public let profiles: [String]?
 
     /// Service-specific config usage (primarily for Swarm)
     public let configs: [ServiceConfig]?
@@ -104,7 +134,7 @@ public struct Service: Codable, Hashable {
     // Defines custom coding keys to map YAML keys to Swift properties
     enum CodingKeys: String, CodingKey {
         case image, build, deploy, restart, healthcheck, volumes, environment, env_file, ports, command, depends_on, user,
-             container_name, networks, hostname, entrypoint, privileged, read_only, working_dir, configs, secrets, stdin_open, tty, platform
+             container_name, networks, hostname, entrypoint, privileged, read_only, tmpfs, cap_add, cap_drop, ulimits, initProcess = "init", security_opt, working_dir, configs, secrets, stdin_open, tty, platform, profiles
     }
     
     /// Public memberwise initializer for testing
@@ -117,18 +147,28 @@ public struct Service: Codable, Hashable {
         volumes: [String]? = nil,
         environment: [String: String]? = nil,
         env_file: [String]? = nil,
+        envFileConfigurations: [ServiceEnvFile]? = nil,
         ports: [String]? = nil,
         command: [String]? = nil,
         depends_on: [String]? = nil,
+        dependencyConfigurations: [String: ServiceDependency]? = nil,
         user: String? = nil,
         container_name: String? = nil,
         networks: [String]? = nil,
+        networkConfigurations: [String: ServiceNetwork]? = nil,
         hostname: String? = nil,
         entrypoint: [String]? = nil,
         privileged: Bool? = nil,
         read_only: Bool? = nil,
+        tmpfs: [String]? = nil,
+        cap_add: [String]? = nil,
+        cap_drop: [String]? = nil,
+        ulimits: [String: ServiceUlimit]? = nil,
+        initProcess: Bool? = nil,
+        security_opt: [String]? = nil,
         working_dir: String? = nil,
         platform: String? = nil,
+        profiles: [String]? = nil,
         configs: [ServiceConfig]? = nil,
         secrets: [ServiceSecret]? = nil,
         stdin_open: Bool? = nil,
@@ -143,18 +183,28 @@ public struct Service: Codable, Hashable {
         self.volumes = volumes
         self.environment = environment
         self.env_file = env_file
+        self.envFileConfigurations = envFileConfigurations
         self.ports = ports
         self.command = command
         self.depends_on = depends_on
+        self.dependencyConfigurations = dependencyConfigurations
         self.user = user
         self.container_name = container_name
         self.networks = networks
+        self.networkConfigurations = networkConfigurations
         self.hostname = hostname
         self.entrypoint = entrypoint
         self.privileged = privileged
         self.read_only = read_only
+        self.tmpfs = tmpfs
+        self.cap_add = cap_add
+        self.cap_drop = cap_drop
+        self.ulimits = ulimits
+        self.initProcess = initProcess
+        self.security_opt = security_opt
         self.working_dir = working_dir
         self.platform = platform
+        self.profiles = profiles
         self.configs = configs
         self.secrets = secrets
         self.stdin_open = stdin_open
@@ -176,48 +226,125 @@ public struct Service: Codable, Hashable {
 
         restart = try container.decodeIfPresent(String.self, forKey: .restart)
         healthcheck = try container.decodeIfPresent(Healthcheck.self, forKey: .healthcheck)
-        volumes = try container.decodeIfPresent([String].self, forKey: .volumes)
-        environment = try container.decodeIfPresent([String: String].self, forKey: .environment)
-        env_file = try container.decodeIfPresent([String].self, forKey: .env_file)
+        volumes = try Self.decodeVolumeList(container, forKey: .volumes)
+        environment = try Self.decodeEnvironment(container, forKey: .environment)
+        if let envFile = try? container.decodeIfPresent(String.self, forKey: .env_file) {
+            env_file = [envFile]
+            envFileConfigurations = [ServiceEnvFile(path: envFile)]
+        } else if let envFiles = try? container.decodeIfPresent([String].self, forKey: .env_file) {
+            env_file = envFiles
+            envFileConfigurations = envFiles.map { ServiceEnvFile(path: $0) }
+        } else if let envFiles = try? container.decodeIfPresent([ServiceEnvFile].self, forKey: .env_file) {
+            env_file = envFiles.map(\.path)
+            envFileConfigurations = envFiles
+        } else {
+            env_file = nil
+            envFileConfigurations = nil
+        }
         ports = try container.decodeIfPresent([String].self, forKey: .ports)
 
         // Decode 'command' which can be either a single string or an array of strings.
         if let cmdArray = try? container.decodeIfPresent([String].self, forKey: .command) {
             command = cmdArray
         } else if let cmdString = try? container.decodeIfPresent(String.self, forKey: .command) {
-            command = [cmdString]
+            command = composeShellSplit(cmdString)
         } else {
             command = nil
         }
         
         if let dependsOnString = try? container.decodeIfPresent(String.self, forKey: .depends_on) {
             depends_on = [dependsOnString]
+            dependencyConfigurations = [dependsOnString: ServiceDependency(condition: "service_started")]
         } else {
-            depends_on = try container.decodeIfPresent([String].self, forKey: .depends_on)
+            if let dependencyList = try? container.decodeIfPresent([String].self, forKey: .depends_on) {
+                depends_on = dependencyList
+                dependencyConfigurations = Dictionary(uniqueKeysWithValues: dependencyList.map {
+                    ($0, ServiceDependency(condition: "service_started"))
+                })
+            } else if let dependencyMap = try? container.decodeIfPresent([String: ServiceDependency].self, forKey: .depends_on) {
+                depends_on = dependencyMap.keys.sorted()
+                dependencyConfigurations = dependencyMap
+            } else {
+                depends_on = nil
+                dependencyConfigurations = nil
+            }
         }
         user = try container.decodeIfPresent(String.self, forKey: .user)
 
         container_name = try container.decodeIfPresent(String.self, forKey: .container_name)
-        networks = try container.decodeIfPresent([String].self, forKey: .networks)
+        if let networkList = try? container.decodeIfPresent([String].self, forKey: .networks) {
+            networks = networkList
+            networkConfigurations = Dictionary(uniqueKeysWithValues: networkList.map {
+                ($0, ServiceNetwork())
+            })
+        } else if let networkMap = try? container.decodeIfPresent([String: ServiceNetwork?].self, forKey: .networks) {
+            networks = networkMap.keys.sorted()
+            networkConfigurations = networkMap.mapValues { $0 ?? ServiceNetwork() }
+        } else {
+            networks = nil
+            networkConfigurations = nil
+        }
         hostname = try container.decodeIfPresent(String.self, forKey: .hostname)
         
         // Decode 'entrypoint' which can be either a single string or an array of strings.
         if let entrypointArray = try? container.decodeIfPresent([String].self, forKey: .entrypoint) {
             entrypoint = entrypointArray
         } else if let entrypointString = try? container.decodeIfPresent(String.self, forKey: .entrypoint) {
-            entrypoint = [entrypointString]
+            entrypoint = composeShellSplit(entrypointString)
         } else {
             entrypoint = nil
         }
 
         privileged = try container.decodeIfPresent(Bool.self, forKey: .privileged)
         read_only = try container.decodeIfPresent(Bool.self, forKey: .read_only)
+        tmpfs = try Self.decodeStringList(container, forKey: .tmpfs)
+        cap_add = try Self.decodeStringList(container, forKey: .cap_add)
+        cap_drop = try Self.decodeStringList(container, forKey: .cap_drop)
+        ulimits = try container.decodeIfPresent([String: ServiceUlimit].self, forKey: .ulimits)
+        initProcess = try container.decodeIfPresent(Bool.self, forKey: .initProcess)
+        security_opt = try Self.decodeStringList(container, forKey: .security_opt)
         working_dir = try container.decodeIfPresent(String.self, forKey: .working_dir)
         configs = try container.decodeIfPresent([ServiceConfig].self, forKey: .configs)
         secrets = try container.decodeIfPresent([ServiceSecret].self, forKey: .secrets)
         stdin_open = try container.decodeIfPresent(Bool.self, forKey: .stdin_open)
         tty = try container.decodeIfPresent(Bool.self, forKey: .tty)
         platform = try container.decodeIfPresent(String.self, forKey: .platform)
+        if let profile = try? container.decodeIfPresent(String.self, forKey: .profiles) {
+            profiles = [profile]
+        } else {
+            profiles = try container.decodeIfPresent([String].self, forKey: .profiles)
+        }
+    }
+
+    private static func decodeStringList(_ container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> [String]? {
+        if let string = try? container.decodeIfPresent(String.self, forKey: key) {
+            return [string]
+        }
+        return try container.decodeIfPresent([String].self, forKey: key)
+    }
+
+    private static func decodeEnvironment(_ container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> [String: String]? {
+        guard container.contains(key) else { return nil }
+        if let mapping = try? container.decode([String: String].self, forKey: key) {
+            return mapping
+        }
+        let entries = try container.decode([String].self, forKey: key)
+        var environment: [String: String] = [:]
+        for entry in entries {
+            let parts = entry.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            if parts.count == 2 {
+                environment[String(parts[0])] = String(parts[1])
+            } else if let value = ProcessInfo.processInfo.environment[entry] {
+                environment[entry] = value
+            }
+        }
+        return environment
+    }
+
+    private static func decodeVolumeList(_ container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> [String]? {
+        guard container.contains(key) else { return nil }
+        let volumes = try container.decode([ServiceVolume].self, forKey: key)
+        return volumes.map(\.mount)
     }
     
     /// Returns the services in topological order based on `depends_on` relationships.

--- a/Sources/Container-Compose/Codable Structs/ServiceDependency.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceDependency.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Service dependency options from Docker Compose long-form `depends_on`.
+public struct ServiceDependency: Codable, Hashable {
+    /// Readiness condition such as `service_started`, `service_healthy`, or `service_completed_successfully`.
+    public let condition: String?
+
+    /// Whether a dependency failure should fail the dependent service.
+    public let required: Bool?
+
+    /// Whether explicit dependency restarts should also restart this service.
+    public let restart: Bool?
+
+    public init(condition: String? = nil, required: Bool? = nil, restart: Bool? = nil) {
+        self.condition = condition
+        self.required = required
+        self.restart = restart
+    }
+}

--- a/Sources/Container-Compose/Codable Structs/ServiceEnvFile.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceEnvFile.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Service `env_file` entry, including Docker Compose long-form object syntax.
+public struct ServiceEnvFile: Codable, Hashable {
+    /// File path to load.
+    public let path: String
+
+    /// Whether the env file is required.
+    public let required: Bool?
+
+    /// Optional file format such as `raw`.
+    public let format: String?
+
+    public init(path: String, required: Bool? = nil, format: String? = nil) {
+        self.path = path
+        self.required = required
+        self.format = format
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case path, required, format
+    }
+
+    public init(from decoder: Decoder) throws {
+        if let path = try? decoder.singleValueContainer().decode(String.self) {
+            self.init(path: path)
+            return
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            path: try container.decode(String.self, forKey: .path),
+            required: try container.decodeIfPresent(Bool.self, forKey: .required),
+            format: try container.decodeIfPresent(String.self, forKey: .format)
+        )
+    }
+}

--- a/Sources/Container-Compose/Codable Structs/ServiceNetwork.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceNetwork.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Service-level network options from Docker Compose map syntax.
+public struct ServiceNetwork: Codable, Hashable {
+    /// Network-scoped service aliases.
+    public let aliases: [String]?
+
+    /// Requested static IPv4 address.
+    public let ipv4_address: String?
+
+    public init(aliases: [String]? = nil, ipv4_address: String? = nil) {
+        self.aliases = aliases
+        self.ipv4_address = ipv4_address
+    }
+}

--- a/Sources/Container-Compose/Codable Structs/ServiceUlimit.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceUlimit.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Docker Compose `ulimits` entry, preserving both scalar and soft/hard forms.
+public struct ServiceUlimit: Codable, Hashable {
+    public let value: String?
+    public let soft: String?
+    public let hard: String?
+
+    public init(value: String? = nil, soft: String? = nil, hard: String? = nil) {
+        self.value = value
+        self.soft = soft
+        self.hard = hard
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case value, soft, hard
+    }
+
+    public init(from decoder: Decoder) throws {
+        if let intValue = try? decoder.singleValueContainer().decode(Int.self) {
+            self.init(value: String(intValue))
+            return
+        }
+        if let stringValue = try? decoder.singleValueContainer().decode(String.self) {
+            self.init(value: stringValue)
+            return
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            soft: try Self.decodeScalar(container, forKey: .soft),
+            hard: try Self.decodeScalar(container, forKey: .hard)
+        )
+    }
+
+    private static func decodeScalar(_ container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> String? {
+        if let intValue = try? container.decodeIfPresent(Int.self, forKey: key) {
+            return String(intValue)
+        }
+        return try container.decodeIfPresent(String.self, forKey: key)
+    }
+}

--- a/Sources/Container-Compose/Codable Structs/ServiceVolume.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceVolume.swift
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+public struct ServiceVolume: Codable, Hashable {
+    public let mount: String
+
+    public init(_ mount: String) {
+        self.mount = mount
+    }
+
+    public init(from decoder: Decoder) throws {
+        let singleValue = try decoder.singleValueContainer()
+        if let mount = try? singleValue.decode(String.self) {
+            self.mount = mount
+            return
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decodeIfPresent(String.self, forKey: .type) ?? "volume"
+        let source = try container.decodeIfPresent(String.self, forKey: .source)
+        let target = try container.decode(String.self, forKey: .target)
+        let readOnly = try container.decodeIfPresent(Bool.self, forKey: .read_only) ?? false
+        let consistency = try container.decodeIfPresent(String.self, forKey: .consistency)
+
+        var options: [String] = []
+        if readOnly {
+            options.append("ro")
+        }
+        if let consistency, !consistency.isEmpty {
+            options.append(consistency)
+        }
+        let suffix = options.isEmpty ? "" : ":\(options.joined(separator: ","))"
+
+        switch type {
+        case "bind":
+            guard let source, !source.isEmpty else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .source,
+                    in: container,
+                    debugDescription: "Bind volume must define 'source'."
+                )
+            }
+            mount = "\(source):\(target)\(suffix)"
+        case "volume":
+            guard let source, !source.isEmpty else {
+                guard options.isEmpty else {
+                    throw DecodingError.dataCorruptedError(
+                        forKey: .source,
+                        in: container,
+                        debugDescription: "Anonymous volumes cannot express mount options in short syntax."
+                    )
+                }
+                mount = target
+                return
+            }
+            mount = "\(source):\(target)\(suffix)"
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unsupported service volume type '\(type)'."
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(mount)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case source
+        case target
+        case read_only
+        case consistency
+    }
+}

--- a/Sources/Container-Compose/Helper Functions.swift
+++ b/Sources/Container-Compose/Helper Functions.swift
@@ -60,6 +60,73 @@ public func loadEnvFile(path: String) -> [String: String] {
     return envVars
 }
 
+public func composeShellSplit(_ input: String) -> [String] {
+    enum Quote {
+        case single
+        case double
+    }
+
+    var tokens: [String] = []
+    var current = ""
+    var quote: Quote?
+    var escaping = false
+    var tokenStarted = false
+
+    for character in input {
+        if escaping {
+            current.append(character)
+            tokenStarted = true
+            escaping = false
+            continue
+        }
+
+        switch quote {
+        case .single:
+            if character == "'" {
+                quote = nil
+            } else {
+                current.append(character)
+            }
+        case .double:
+            if character == "\"" {
+                quote = nil
+            } else if character == "\\" {
+                escaping = true
+            } else {
+                current.append(character)
+            }
+        case nil:
+            if character == "\\" {
+                escaping = true
+                tokenStarted = true
+            } else if character == "'" {
+                quote = .single
+                tokenStarted = true
+            } else if character == "\"" {
+                quote = .double
+                tokenStarted = true
+            } else if character.isWhitespace {
+                if tokenStarted {
+                    tokens.append(current)
+                    current = ""
+                    tokenStarted = false
+                }
+            } else {
+                current.append(character)
+                tokenStarted = true
+            }
+        }
+    }
+
+    if escaping {
+        current.append("\\")
+    }
+    if tokenStarted {
+        tokens.append(current)
+    }
+    return tokens
+}
+
 /// Resolves environment variables within a string (e.g., ${VAR:-default}, ${VAR:?error}).
 /// This function supports default values and error-on-missing variable syntax.
 /// - Parameters:

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -140,7 +140,25 @@ struct DockerComposeParsingTests {
         #expect(compose.services["app"]??.environment?["DATABASE_URL"] == "postgres://localhost/mydb")
         #expect(compose.services["app"]??.environment?["DEBUG"] == "true")
     }
-    
+
+    @Test("Parse compose with environment list")
+    func parseComposeWithEnvironmentList() throws {
+        let yaml = """
+        services:
+          app:
+            image: alpine:latest
+            environment:
+              - REDIS_CLUSTER=yes
+              - EMPTY_VALUE=
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+
+        #expect(compose.services["app"]??.environment?["REDIS_CLUSTER"] == "yes")
+        #expect(compose.services["app"]??.environment?["EMPTY_VALUE"] == "")
+    }
+
     @Test("Parse compose with ports")
     func parseComposeWithPorts() throws {
         let yaml = """
@@ -178,6 +196,65 @@ struct DockerComposeParsingTests {
         let compose = try decoder.decode(DockerCompose.self, from: yaml)
         
         #expect(compose.services["web"]??.depends_on?.contains("db") == true)
+    }
+
+    @Test("Parse compose with profiles")
+    func parseComposeWithProfiles() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: alpine:latest
+            profiles:
+              - dev
+              - ci
+          worker:
+            image: alpine:latest
+            profiles: batch
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+
+        #expect(compose.services["app"]??.profiles == ["dev", "ci"])
+        #expect(compose.services["worker"]??.profiles == ["batch"])
+    }
+
+    @Test("Parse compose runtime options")
+    func parseComposeRuntimeOptions() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: alpine:latest
+            tmpfs:
+              - /run
+              - /tmp:size=64m
+            cap_add:
+              - NET_ADMIN
+            cap_drop: ALL
+            ulimits:
+              nofile:
+                soft: 1024
+                hard: 2048
+              nproc: 65535
+            init: true
+            security_opt:
+              - "no-new-privileges:true"
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+        let app = try #require(compose.services["app"] ?? nil)
+
+        #expect(app.tmpfs == ["/run", "/tmp:size=64m"])
+        #expect(app.cap_add == ["NET_ADMIN"])
+        #expect(app.cap_drop == ["ALL"])
+        #expect(app.ulimits?["nofile"]?.soft == "1024")
+        #expect(app.ulimits?["nofile"]?.hard == "2048")
+        #expect(app.ulimits?["nproc"]?.value == "65535")
+        #expect(app.initProcess == true)
+        #expect(app.security_opt == ["no-new-privileges:true"])
     }
     
     @Test("Parse compose with build context")
@@ -229,8 +306,27 @@ struct DockerComposeParsingTests {
         let decoder = YAMLDecoder()
         let compose = try decoder.decode(DockerCompose.self, from: yaml)
         
-        #expect(compose.services["app"]??.command?.count == 1)
-        #expect(compose.services["app"]??.command?.first == "echo hello")
+        #expect(compose.services["app"]??.command == ["echo", "hello"])
+    }
+
+    @Test("Parse compose command string with quotes")
+    func parseComposeCommandStringWithQuotes() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: alpine:latest
+            command: --enable-debug-command yes --save ""
+          shell:
+            image: alpine:latest
+            entrypoint: sh -lc "echo hello world"
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+
+        #expect(compose.services["app"]??.command == ["--enable-debug-command", "yes", "--save", ""])
+        #expect(compose.services["shell"]??.entrypoint == ["sh", "-lc", "echo hello world"])
     }
     
     @Test("Parse compose with restart policy")

--- a/Tests/Container-Compose-StaticTests/NetworkConfigurationTests.swift
+++ b/Tests/Container-Compose-StaticTests/NetworkConfigurationTests.swift
@@ -65,7 +65,53 @@ struct NetworkConfigurationTests {
         #expect(compose.services["app"]??.networks?.contains("frontend") == true)
         #expect(compose.services["app"]??.networks?.contains("backend") == true)
     }
-    
+
+    @Test("Parse service network object syntax")
+    func parseServiceNetworkObjectSyntax() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: myapp:latest
+            networks:
+              backend:
+                aliases:
+                  - app.local
+                ipv4_address: 10.10.0.5
+        networks:
+          backend:
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+        let app = try #require(compose.services["app"] ?? nil)
+
+        #expect(app.networks == ["backend"])
+        #expect(app.networkConfigurations?["backend"]?.aliases == ["app.local"])
+        #expect(app.networkConfigurations?["backend"]?.ipv4_address == "10.10.0.5")
+    }
+
+    @Test("Parse service network object syntax with null value")
+    func parseServiceNetworkObjectSyntaxWithNullValue() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          redis:
+            image: redis:alpine
+            networks:
+              netbridge:
+        networks:
+          netbridge:
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+        let redis = try #require(compose.services["redis"] ?? nil)
+
+        #expect(redis.networks == ["netbridge"])
+        #expect(redis.networkConfigurations?["netbridge"] == ServiceNetwork())
+    }
+
     @Test("Parse network with driver")
     func parseNetworkWithDriver() throws {
         let yaml = """
@@ -121,7 +167,25 @@ struct NetworkConfigurationTests {
         #expect(network.labels?["com.example.description"] == "Frontend Network")
         #expect(network.labels?["com.example.version"] == "1.0")
     }
-    
+
+    @Test("Parse network ipam subnets")
+    func parseNetworkIPAMSubnets() throws {
+        let yaml = """
+        internal: true
+        ipam:
+          config:
+            - subnet: 172.18.0.0/16
+            - subnet: fd00:abcd::/64
+        """
+
+        let decoder = YAMLDecoder()
+        let network = try decoder.decode(Network.self, from: yaml)
+
+        #expect(network.isInternal == true)
+        #expect(network.ipam?.ipv4Subnet == "172.18.0.0/16")
+        #expect(network.ipam?.ipv6Subnet == "fd00:abcd::/64")
+    }
+
     @Test("Multiple networks in compose")
     func multipleNetworksInCompose() throws {
         let yaml = """
@@ -187,4 +251,3 @@ struct NetworkConfigurationTests {
         #expect(compose.services["web"] != nil)
     }
 }
-

--- a/Tests/Container-Compose-StaticTests/ServiceDependencyTests.swift
+++ b/Tests/Container-Compose-StaticTests/ServiceDependencyTests.swift
@@ -16,6 +16,7 @@
 
 import Testing
 import Foundation
+@testable import Yams
 @testable import ContainerComposeCore
 
 @Suite("Service Dependency Resolution Tests")
@@ -51,6 +52,43 @@ struct ServiceDependencyTests {
         let firstTwo = Set([sorted[0].serviceName, sorted[1].serviceName])
         #expect(firstTwo.contains("db"))
         #expect(firstTwo.contains("redis"))
+    }
+
+    @Test("Parse long-form depends_on conditions")
+    func parseLongFormDependsOnConditions() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: myapp:latest
+            depends_on:
+              db:
+                condition: service_healthy
+                required: true
+              init:
+                condition: service_completed_successfully
+                restart: false
+              optional_metrics:
+                condition: service_started
+                required: false
+          db:
+            image: postgres:16
+          init:
+            image: alpine:latest
+          optional_metrics:
+            image: alpine:latest
+        """
+
+        let compose = try YAMLDecoder().decode(DockerCompose.self, from: yaml)
+        let app = try #require(compose.services["app"] ?? nil)
+
+        #expect(app.depends_on == ["db", "init", "optional_metrics"])
+        #expect(app.dependencyConfigurations?["db"]?.condition == "service_healthy")
+        #expect(app.dependencyConfigurations?["db"]?.required == true)
+        #expect(app.dependencyConfigurations?["init"]?.condition == "service_completed_successfully")
+        #expect(app.dependencyConfigurations?["init"]?.restart == false)
+        #expect(app.dependencyConfigurations?["optional_metrics"]?.condition == "service_started")
+        #expect(app.dependencyConfigurations?["optional_metrics"]?.required == false)
     }
     
     @Test("Complex dependency chain - web -> app -> db")
@@ -121,15 +159,14 @@ struct ServiceDependencyTests {
         #expect(sorted[0].serviceName == "web")
     }
     
-    @Test("Service depends on non-existent service - should not crash")
-    func dependsOnNonExistentService() throws {
+    @Test("Topological sort leaves missing dependency validation to service selection")
+    func topologicalSortLeavesMissingDependencyValidationToServiceSelection() throws {
         let web = Service(image: "nginx", depends_on: ["nonexistent"])
         
         let services: [(String, Service)] = [("web", web)]
         let sorted = try Service.topoSortConfiguredServices(services)
         
-        // Should complete without crashing
+        // The lower-level sort helper preserves legacy tolerance; lifecycle selection fails fast.
         #expect(sorted.count == 1)
     }
 }
-


### PR DESCRIPTION
## Summary

- expose the core Compose implementation as a reusable SwiftPM product
- add backwards-compatible parsing for common Compose schema variants
- cover service/network/dependency forms without changing runtime behavior beyond parser compatibility

## Notes

This PR is intentionally static-first. Runtime orchestration changes are split into later PRs so parser compatibility can be reviewed independently.

## Verification

```bash
swift test --filter 'DockerComposeParsingTests|ServiceDependencyTests|NetworkConfigurationTests'\nswift test --filter Container_Compose_StaticTests\n```