### PR TITLE
Expose SwiftPM products

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,10 @@ import PackageDescription
 let package = Package(
     name: "Container-Compose",
     platforms: [.macOS(.v15)],
+    products: [
+        .library(name: "ContainerComposeCore", targets: ["ContainerComposeCore"]),
+        .executable(name: "container-compose", targets: ["Container-Compose"]),
+    ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.1"),
         .package(url: "https://github.com/mcrich23/container", branch: "add-command-option-group-function-macro"),


### PR DESCRIPTION
## Summary
- expose ContainerComposeCore as a reusable SwiftPM library product
- expose the existing executable target as the container-compose product

## Notes
Split out of #85 so the package surface change can be reviewed separately from parser compatibility changes.

## Verification
- git diff --check
- swift build --product ContainerComposeCore
- swift build --product container-compose