### PR TITLE
Parse Compose environment forms

### DIFF
--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -239,20 +239,60 @@ public struct Service: Codable, Hashable {
 
     private static func decodeEnvironment(_ container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> [String: String]? {
         guard container.contains(key) else { return nil }
-        if let mapping = try? container.decode([String: String].self, forKey: key) {
-            return mapping
+        if let mapping = try? container.decode([String: EnvironmentValue].self, forKey: key) {
+            var environment: [String: String] = [:]
+            for (name, value) in mapping {
+                if let value = value.value {
+                    environment[name] = value
+                } else if let value = ProcessInfo.processInfo.environment[name] {
+                    environment[name] = value
+                }
+            }
+            return environment
         }
         let entries = try container.decode([String].self, forKey: key)
         var environment: [String: String] = [:]
         for entry in entries {
             let parts = entry.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
             if parts.count == 2 {
-                environment[String(parts[0])] = String(parts[1])
+                let name = String(parts[0])
+                if name.last?.isWhitespace == true {
+                    throw DecodingError.dataCorruptedError(
+                        forKey: key,
+                        in: container,
+                        debugDescription: "environment variable '\(name)' is declared with a trailing space"
+                    )
+                }
+                environment[name] = String(parts[1])
             } else if let value = ProcessInfo.processInfo.environment[entry] {
                 environment[entry] = value
             }
         }
         return environment
+    }
+
+    private struct EnvironmentValue: Decodable {
+        let value: String?
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if container.decodeNil() {
+                value = nil
+            } else if let string = try? container.decode(String.self) {
+                value = string
+            } else if let bool = try? container.decode(Bool.self) {
+                value = String(bool)
+            } else if let int = try? container.decode(Int.self) {
+                value = String(int)
+            } else if let double = try? container.decode(Double.self) {
+                value = String(double)
+            } else {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "environment values must be string, number, boolean, or null"
+                )
+            }
+        }
     }
     
     /// Returns the services in topological order based on `depends_on` relationships.

--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -50,6 +50,9 @@ public struct Service: Codable, Hashable {
     /// List of .env files to load environment variables from
     public let env_file: [String]?
 
+    /// Detailed env file entries keyed by list order
+    public let envFileConfigurations: [ServiceEnvFile]?
+
     /// Port mappings (e.g., "hostPort:containerPort")
     public let ports: [String]?
 
@@ -117,6 +120,7 @@ public struct Service: Codable, Hashable {
         volumes: [String]? = nil,
         environment: [String: String]? = nil,
         env_file: [String]? = nil,
+        envFileConfigurations: [ServiceEnvFile]? = nil,
         ports: [String]? = nil,
         command: [String]? = nil,
         depends_on: [String]? = nil,
@@ -143,6 +147,7 @@ public struct Service: Codable, Hashable {
         self.volumes = volumes
         self.environment = environment
         self.env_file = env_file
+        self.envFileConfigurations = envFileConfigurations
         self.ports = ports
         self.command = command
         self.depends_on = depends_on
@@ -177,8 +182,20 @@ public struct Service: Codable, Hashable {
         restart = try container.decodeIfPresent(String.self, forKey: .restart)
         healthcheck = try container.decodeIfPresent(Healthcheck.self, forKey: .healthcheck)
         volumes = try container.decodeIfPresent([String].self, forKey: .volumes)
-        environment = try container.decodeIfPresent([String: String].self, forKey: .environment)
-        env_file = try container.decodeIfPresent([String].self, forKey: .env_file)
+        environment = try Self.decodeEnvironment(container, forKey: .environment)
+        if let envFile = try? container.decodeIfPresent(String.self, forKey: .env_file) {
+            env_file = [envFile]
+            envFileConfigurations = [ServiceEnvFile(path: envFile)]
+        } else if let envFiles = try? container.decodeIfPresent([String].self, forKey: .env_file) {
+            env_file = envFiles
+            envFileConfigurations = envFiles.map { ServiceEnvFile(path: $0) }
+        } else if let envFiles = try? container.decodeIfPresent([ServiceEnvFile].self, forKey: .env_file) {
+            env_file = envFiles.map(\.path)
+            envFileConfigurations = envFiles
+        } else {
+            env_file = nil
+            envFileConfigurations = nil
+        }
         ports = try container.decodeIfPresent([String].self, forKey: .ports)
 
         // Decode 'command' which can be either a single string or an array of strings.
@@ -218,6 +235,24 @@ public struct Service: Codable, Hashable {
         stdin_open = try container.decodeIfPresent(Bool.self, forKey: .stdin_open)
         tty = try container.decodeIfPresent(Bool.self, forKey: .tty)
         platform = try container.decodeIfPresent(String.self, forKey: .platform)
+    }
+
+    private static func decodeEnvironment(_ container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> [String: String]? {
+        guard container.contains(key) else { return nil }
+        if let mapping = try? container.decode([String: String].self, forKey: key) {
+            return mapping
+        }
+        let entries = try container.decode([String].self, forKey: key)
+        var environment: [String: String] = [:]
+        for entry in entries {
+            let parts = entry.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            if parts.count == 2 {
+                environment[String(parts[0])] = String(parts[1])
+            } else if let value = ProcessInfo.processInfo.environment[entry] {
+                environment[entry] = value
+            }
+        }
+        return environment
     }
     
     /// Returns the services in topological order based on `depends_on` relationships.

--- a/Sources/Container-Compose/Codable Structs/ServiceEnvFile.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceEnvFile.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Service `env_file` entry, including Docker Compose long-form object syntax.
+public struct ServiceEnvFile: Codable, Hashable {
+    /// File path to load.
+    public let path: String
+
+    /// Whether the env file is required.
+    public let required: Bool?
+
+    /// Optional file format such as `raw`.
+    public let format: String?
+
+    public init(path: String, required: Bool? = nil, format: String? = nil) {
+        self.path = path
+        self.required = required
+        self.format = format
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case path, required, format
+    }
+
+    public init(from decoder: Decoder) throws {
+        if let path = try? decoder.singleValueContainer().decode(String.self) {
+            self.init(path: path)
+            return
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            path: try container.decode(String.self, forKey: .path),
+            required: try container.decodeIfPresent(Bool.self, forKey: .required),
+            format: try container.decodeIfPresent(String.self, forKey: .format)
+        )
+    }
+}

--- a/Sources/Container-Compose/Codable Structs/ServiceEnvFile.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceEnvFile.swift
@@ -25,7 +25,7 @@ public struct ServiceEnvFile: Codable, Hashable {
     /// Optional file format such as `raw`.
     public let format: String?
 
-    public init(path: String, required: Bool? = nil, format: String? = nil) {
+    public init(path: String, required: Bool? = true, format: String? = nil) {
         self.path = path
         self.required = required
         self.format = format
@@ -43,7 +43,7 @@ public struct ServiceEnvFile: Codable, Hashable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.init(
             path: try container.decode(String.self, forKey: .path),
-            required: try container.decodeIfPresent(Bool.self, forKey: .required),
+            required: try container.decodeIfPresent(Bool.self, forKey: .required) ?? true,
             format: try container.decodeIfPresent(String.self, forKey: .format)
         )
     }

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -140,7 +140,25 @@ struct DockerComposeParsingTests {
         #expect(compose.services["app"]??.environment?["DATABASE_URL"] == "postgres://localhost/mydb")
         #expect(compose.services["app"]??.environment?["DEBUG"] == "true")
     }
-    
+
+    @Test("Parse compose with environment list")
+    func parseComposeWithEnvironmentList() throws {
+        let yaml = """
+        services:
+          app:
+            image: alpine:latest
+            environment:
+              - REDIS_CLUSTER=yes
+              - EMPTY_VALUE=
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+
+        #expect(compose.services["app"]??.environment?["REDIS_CLUSTER"] == "yes")
+        #expect(compose.services["app"]??.environment?["EMPTY_VALUE"] == "")
+    }
+
     @Test("Parse compose with ports")
     func parseComposeWithPorts() throws {
         let yaml = """

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -159,6 +159,55 @@ struct DockerComposeParsingTests {
         #expect(compose.services["app"]??.environment?["EMPTY_VALUE"] == "")
     }
 
+    @Test("Parse compose with Docker-compatible environment scalars")
+    func parseComposeWithEnvironmentScalars() throws {
+        setenv("HOST_ENV_VALUE", "from-host", 1)
+        defer { unsetenv("HOST_ENV_VALUE") }
+
+        let yaml = """
+        services:
+          app:
+            image: alpine:latest
+            environment:
+              FOO: "1"
+              BAR: 2
+              ENABLED: true
+              EMPTY_VALUE: ""
+              UNSET_VALUE:
+              HOST_ENV_VALUE:
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+        let environment = try #require(compose.services["app"]??.environment)
+
+        #expect(environment["FOO"] == "1")
+        #expect(environment["BAR"] == "2")
+        #expect(environment["ENABLED"] == "true")
+        #expect(environment["EMPTY_VALUE"] == "")
+        #expect(environment["UNSET_VALUE"] == nil)
+        #expect(environment["HOST_ENV_VALUE"] == "from-host")
+    }
+
+    @Test("Parse compose env_file defaults required")
+    func parseComposeEnvFileDefaultsRequired() throws {
+        let yaml = """
+        services:
+          app:
+            image: alpine:latest
+            env_file:
+              - .env
+              - path: .env.local
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+        let envFiles = try #require(compose.services["app"]??.envFileConfigurations)
+
+        #expect(envFiles.map(\.path) == [".env", ".env.local"])
+        #expect(envFiles.allSatisfy { $0.required == true })
+    }
+
     @Test("Parse compose with ports")
     func parseComposeWithPorts() throws {
         let yaml = """


### PR DESCRIPTION
## Summary
- parse Compose `environment` list entries into the existing environment map
- preserve `env_file` scalar, list, and long-form object entries through `ServiceEnvFile`

## Notes
Split out of #85 so environment parsing compatibility can be reviewed independently.

## Verification
- git diff --check
- swift test --filter DockerComposeParsingTests