### PR TITLE
Parse service dependencies and profiles

### DIFF
--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -59,6 +59,9 @@ public struct Service: Codable, Hashable {
     /// Services this service depends on (for startup order)
     public let depends_on: [String]?
 
+    /// Detailed dependency options keyed by service name
+    public let dependencyConfigurations: [String: ServiceDependency]?
+
     /// User or UID to run the container as
     public let user: String?
 
@@ -86,6 +89,9 @@ public struct Service: Codable, Hashable {
     /// Platform architecture for the service
     public let platform: String?
 
+    /// Profiles that activate this service
+    public let profiles: [String]?
+
     /// Service-specific config usage (primarily for Swarm)
     public let configs: [ServiceConfig]?
 
@@ -104,7 +110,7 @@ public struct Service: Codable, Hashable {
     // Defines custom coding keys to map YAML keys to Swift properties
     enum CodingKeys: String, CodingKey {
         case image, build, deploy, restart, healthcheck, volumes, environment, env_file, ports, command, depends_on, user,
-             container_name, networks, hostname, entrypoint, privileged, read_only, working_dir, configs, secrets, stdin_open, tty, platform
+             container_name, networks, hostname, entrypoint, privileged, read_only, working_dir, configs, secrets, stdin_open, tty, platform, profiles
     }
     
     /// Public memberwise initializer for testing
@@ -120,6 +126,7 @@ public struct Service: Codable, Hashable {
         ports: [String]? = nil,
         command: [String]? = nil,
         depends_on: [String]? = nil,
+        dependencyConfigurations: [String: ServiceDependency]? = nil,
         user: String? = nil,
         container_name: String? = nil,
         networks: [String]? = nil,
@@ -129,6 +136,7 @@ public struct Service: Codable, Hashable {
         read_only: Bool? = nil,
         working_dir: String? = nil,
         platform: String? = nil,
+        profiles: [String]? = nil,
         configs: [ServiceConfig]? = nil,
         secrets: [ServiceSecret]? = nil,
         stdin_open: Bool? = nil,
@@ -146,6 +154,7 @@ public struct Service: Codable, Hashable {
         self.ports = ports
         self.command = command
         self.depends_on = depends_on
+        self.dependencyConfigurations = dependencyConfigurations
         self.user = user
         self.container_name = container_name
         self.networks = networks
@@ -155,6 +164,7 @@ public struct Service: Codable, Hashable {
         self.read_only = read_only
         self.working_dir = working_dir
         self.platform = platform
+        self.profiles = profiles
         self.configs = configs
         self.secrets = secrets
         self.stdin_open = stdin_open
@@ -192,8 +202,20 @@ public struct Service: Codable, Hashable {
         
         if let dependsOnString = try? container.decodeIfPresent(String.self, forKey: .depends_on) {
             depends_on = [dependsOnString]
+            dependencyConfigurations = [dependsOnString: ServiceDependency(condition: "service_started")]
         } else {
-            depends_on = try container.decodeIfPresent([String].self, forKey: .depends_on)
+            if let dependencyList = try? container.decodeIfPresent([String].self, forKey: .depends_on) {
+                depends_on = dependencyList
+                dependencyConfigurations = Dictionary(uniqueKeysWithValues: dependencyList.map {
+                    ($0, ServiceDependency(condition: "service_started"))
+                })
+            } else if let dependencyMap = try? container.decodeIfPresent([String: ServiceDependency].self, forKey: .depends_on) {
+                depends_on = dependencyMap.keys.sorted()
+                dependencyConfigurations = dependencyMap
+            } else {
+                depends_on = nil
+                dependencyConfigurations = nil
+            }
         }
         user = try container.decodeIfPresent(String.self, forKey: .user)
 
@@ -218,6 +240,11 @@ public struct Service: Codable, Hashable {
         stdin_open = try container.decodeIfPresent(Bool.self, forKey: .stdin_open)
         tty = try container.decodeIfPresent(Bool.self, forKey: .tty)
         platform = try container.decodeIfPresent(String.self, forKey: .platform)
+        if let profile = try? container.decodeIfPresent(String.self, forKey: .profiles) {
+            profiles = [profile]
+        } else {
+            profiles = try container.decodeIfPresent([String].self, forKey: .profiles)
+        }
     }
     
     /// Returns the services in topological order based on `depends_on` relationships.

--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -240,11 +240,7 @@ public struct Service: Codable, Hashable {
         stdin_open = try container.decodeIfPresent(Bool.self, forKey: .stdin_open)
         tty = try container.decodeIfPresent(Bool.self, forKey: .tty)
         platform = try container.decodeIfPresent(String.self, forKey: .platform)
-        if let profile = try? container.decodeIfPresent(String.self, forKey: .profiles) {
-            profiles = [profile]
-        } else {
-            profiles = try container.decodeIfPresent([String].self, forKey: .profiles)
-        }
+        profiles = try container.decodeIfPresent([String].self, forKey: .profiles)
     }
     
     /// Returns the services in topological order based on `depends_on` relationships.

--- a/Sources/Container-Compose/Codable Structs/ServiceDependency.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceDependency.swift
@@ -25,9 +25,22 @@ public struct ServiceDependency: Codable, Hashable {
     /// Whether explicit dependency restarts should also restart this service.
     public let restart: Bool?
 
-    public init(condition: String? = nil, required: Bool? = nil, restart: Bool? = nil) {
+    public init(condition: String? = "service_started", required: Bool? = true, restart: Bool? = nil) {
         self.condition = condition
         self.required = required
         self.restart = restart
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case condition, required, restart
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            condition: try container.decodeIfPresent(String.self, forKey: .condition) ?? "service_started",
+            required: try container.decodeIfPresent(Bool.self, forKey: .required) ?? true,
+            restart: try container.decodeIfPresent(Bool.self, forKey: .restart)
+        )
     }
 }

--- a/Sources/Container-Compose/Codable Structs/ServiceDependency.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceDependency.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Service dependency options from Docker Compose long-form `depends_on`.
+public struct ServiceDependency: Codable, Hashable {
+    /// Readiness condition such as `service_started`, `service_healthy`, or `service_completed_successfully`.
+    public let condition: String?
+
+    /// Whether a dependency failure should fail the dependent service.
+    public let required: Bool?
+
+    /// Whether explicit dependency restarts should also restart this service.
+    public let restart: Bool?
+
+    public init(condition: String? = nil, required: Bool? = nil, restart: Bool? = nil) {
+        self.condition = condition
+        self.required = required
+        self.restart = restart
+    }
+}

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -179,6 +179,28 @@ struct DockerComposeParsingTests {
         
         #expect(compose.services["web"]??.depends_on?.contains("db") == true)
     }
+
+    @Test("Parse compose with profiles")
+    func parseComposeWithProfiles() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: alpine:latest
+            profiles:
+              - dev
+              - ci
+          worker:
+            image: alpine:latest
+            profiles: batch
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+
+        #expect(compose.services["app"]??.profiles == ["dev", "ci"])
+        #expect(compose.services["worker"]??.profiles == ["batch"])
+    }
     
     @Test("Parse compose with build context")
     func parseComposeWithBuild() throws {

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -192,7 +192,8 @@ struct DockerComposeParsingTests {
               - ci
           worker:
             image: alpine:latest
-            profiles: batch
+            profiles:
+              - batch
         """
 
         let decoder = YAMLDecoder()

--- a/Tests/Container-Compose-StaticTests/ServiceDependencyTests.swift
+++ b/Tests/Container-Compose-StaticTests/ServiceDependencyTests.swift
@@ -86,6 +86,7 @@ struct ServiceDependencyTests {
         #expect(app.dependencyConfigurations?["db"]?.condition == "service_healthy")
         #expect(app.dependencyConfigurations?["db"]?.required == true)
         #expect(app.dependencyConfigurations?["init"]?.condition == "service_completed_successfully")
+        #expect(app.dependencyConfigurations?["init"]?.required == true)
         #expect(app.dependencyConfigurations?["init"]?.restart == false)
         #expect(app.dependencyConfigurations?["optional_metrics"]?.condition == "service_started")
         #expect(app.dependencyConfigurations?["optional_metrics"]?.required == false)

--- a/Tests/Container-Compose-StaticTests/ServiceDependencyTests.swift
+++ b/Tests/Container-Compose-StaticTests/ServiceDependencyTests.swift
@@ -16,6 +16,7 @@
 
 import Testing
 import Foundation
+@testable import Yams
 @testable import ContainerComposeCore
 
 @Suite("Service Dependency Resolution Tests")
@@ -51,6 +52,43 @@ struct ServiceDependencyTests {
         let firstTwo = Set([sorted[0].serviceName, sorted[1].serviceName])
         #expect(firstTwo.contains("db"))
         #expect(firstTwo.contains("redis"))
+    }
+
+    @Test("Parse long-form depends_on conditions")
+    func parseLongFormDependsOnConditions() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: myapp:latest
+            depends_on:
+              db:
+                condition: service_healthy
+                required: true
+              init:
+                condition: service_completed_successfully
+                restart: false
+              optional_metrics:
+                condition: service_started
+                required: false
+          db:
+            image: postgres:16
+          init:
+            image: alpine:latest
+          optional_metrics:
+            image: alpine:latest
+        """
+
+        let compose = try YAMLDecoder().decode(DockerCompose.self, from: yaml)
+        let app = try #require(compose.services["app"] ?? nil)
+
+        #expect(app.depends_on == ["db", "init", "optional_metrics"])
+        #expect(app.dependencyConfigurations?["db"]?.condition == "service_healthy")
+        #expect(app.dependencyConfigurations?["db"]?.required == true)
+        #expect(app.dependencyConfigurations?["init"]?.condition == "service_completed_successfully")
+        #expect(app.dependencyConfigurations?["init"]?.restart == false)
+        #expect(app.dependencyConfigurations?["optional_metrics"]?.condition == "service_started")
+        #expect(app.dependencyConfigurations?["optional_metrics"]?.required == false)
     }
     
     @Test("Complex dependency chain - web -> app -> db")
@@ -121,15 +159,14 @@ struct ServiceDependencyTests {
         #expect(sorted[0].serviceName == "web")
     }
     
-    @Test("Service depends on non-existent service - should not crash")
-    func dependsOnNonExistentService() throws {
+    @Test("Topological sort leaves missing dependency validation to service selection")
+    func topologicalSortLeavesMissingDependencyValidationToServiceSelection() throws {
         let web = Service(image: "nginx", depends_on: ["nonexistent"])
         
         let services: [(String, Service)] = [("web", web)]
         let sorted = try Service.topoSortConfiguredServices(services)
         
-        // Should complete without crashing
+        // The lower-level sort helper preserves legacy tolerance; lifecycle selection fails fast.
         #expect(sorted.count == 1)
     }
 }
-


### PR DESCRIPTION
## Summary
- parse long-form depends_on conditions into ServiceDependency metadata
- preserve the existing sorted depends_on service list for startup ordering
- parse scalar and list profiles values

## Notes
Split out of #85 so dependency/profile metadata can be reviewed independently.

## Verification
- git diff --check
- swift test --filter ServiceDependencyTests
- swift test --filter DockerComposeParsingTests