### PR TITLE
Parse Compose network options

### DIFF
--- a/Sources/Container-Compose/Codable Structs/Network.swift
+++ b/Sources/Container-Compose/Codable Structs/Network.swift
@@ -40,10 +40,12 @@ public struct Network: Codable {
     public let name: String?
     /// Indicates if the network is external (pre-existing)
     public let external: ExternalNetwork?
+    /// IPAM configuration for subnets and related allocation options.
+    public let ipam: NetworkIPAM?
 
     /// Updated CodingKeys to map 'internal' from YAML to 'isInternal' Swift property
     enum CodingKeys: String, CodingKey {
-        case driver, driver_opts, attachable, enable_ipv6, isInternal = "internal", labels, name, external
+        case driver, driver_opts, attachable, enable_ipv6, isInternal = "internal", labels, name, external, ipam
     }
 
     /// Custom initializer to handle `external: true` (boolean) or `external: { name: "my_net" }` (object).
@@ -56,6 +58,7 @@ public struct Network: Codable {
         isInternal = try container.decodeIfPresent(Bool.self, forKey: .isInternal) // Use isInternal here
         labels = try container.decodeIfPresent([String: String].self, forKey: .labels)
         name = try container.decodeIfPresent(String.self, forKey: .name)
+        ipam = try container.decodeIfPresent(NetworkIPAM.self, forKey: .ipam)
 
         if let externalBool = try? container.decodeIfPresent(Bool.self, forKey: .external) {
             external = ExternalNetwork(isExternal: externalBool, name: nil)
@@ -64,5 +67,35 @@ public struct Network: Codable {
         } else {
             external = nil
         }
+    }
+
+}
+
+public struct NetworkIPAM: Codable {
+    public let driver: String?
+    public let config: [NetworkIPAMConfig]?
+    public let options: [String: String]?
+
+    public var ipv4Subnet: String? {
+        config?.compactMap(\.subnet).first { !$0.contains(":") }
+    }
+
+    public var ipv6Subnet: String? {
+        config?.compactMap(\.subnet).first { $0.contains(":") }
+    }
+
+}
+
+public struct NetworkIPAMConfig: Codable {
+    public let subnet: String?
+    public let ipRange: String?
+    public let gateway: String?
+    public let auxAddresses: [String: String]?
+
+    enum CodingKeys: String, CodingKey {
+        case subnet
+        case ipRange = "ip_range"
+        case gateway
+        case auxAddresses = "aux_addresses"
     }
 }

--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -68,6 +68,9 @@ public struct Service: Codable, Hashable {
     /// List of networks the service will connect to
     public let networks: [String]?
 
+    /// Service-level network options keyed by network name
+    public let networkConfigurations: [String: ServiceNetwork]?
+
     /// Container hostname
     public let hostname: String?
 
@@ -123,6 +126,7 @@ public struct Service: Codable, Hashable {
         user: String? = nil,
         container_name: String? = nil,
         networks: [String]? = nil,
+        networkConfigurations: [String: ServiceNetwork]? = nil,
         hostname: String? = nil,
         entrypoint: [String]? = nil,
         privileged: Bool? = nil,
@@ -149,6 +153,7 @@ public struct Service: Codable, Hashable {
         self.user = user
         self.container_name = container_name
         self.networks = networks
+        self.networkConfigurations = networkConfigurations
         self.hostname = hostname
         self.entrypoint = entrypoint
         self.privileged = privileged
@@ -198,7 +203,18 @@ public struct Service: Codable, Hashable {
         user = try container.decodeIfPresent(String.self, forKey: .user)
 
         container_name = try container.decodeIfPresent(String.self, forKey: .container_name)
-        networks = try container.decodeIfPresent([String].self, forKey: .networks)
+        if let networkList = try? container.decodeIfPresent([String].self, forKey: .networks) {
+            networks = networkList
+            networkConfigurations = Dictionary(uniqueKeysWithValues: networkList.map {
+                ($0, ServiceNetwork())
+            })
+        } else if let networkMap = try? container.decodeIfPresent([String: ServiceNetwork?].self, forKey: .networks) {
+            networks = networkMap.keys.sorted()
+            networkConfigurations = networkMap.mapValues { $0 ?? ServiceNetwork() }
+        } else {
+            networks = nil
+            networkConfigurations = nil
+        }
         hostname = try container.decodeIfPresent(String.self, forKey: .hostname)
         
         // Decode 'entrypoint' which can be either a single string or an array of strings.

--- a/Sources/Container-Compose/Codable Structs/ServiceNetwork.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceNetwork.swift
@@ -19,11 +19,49 @@ public struct ServiceNetwork: Codable, Hashable {
     /// Network-scoped service aliases.
     public let aliases: [String]?
 
+    /// Driver options applied to this network attachment.
+    public let driver_opts: [String: String]?
+
+    /// Gateway priority for this network attachment.
+    public let gw_priority: Int?
+
+    /// Requested interface name inside the container.
+    public let interface_name: String?
+
     /// Requested static IPv4 address.
     public let ipv4_address: String?
 
-    public init(aliases: [String]? = nil, ipv4_address: String? = nil) {
+    /// Requested static IPv6 address.
+    public let ipv6_address: String?
+
+    /// Link-local IP addresses for this network attachment.
+    public let link_local_ips: [String]?
+
+    /// Requested MAC address for this network attachment.
+    public let mac_address: String?
+
+    /// Network attachment priority.
+    public let priority: Int?
+
+    public init(
+        aliases: [String]? = nil,
+        driver_opts: [String: String]? = nil,
+        gw_priority: Int? = nil,
+        interface_name: String? = nil,
+        ipv4_address: String? = nil,
+        ipv6_address: String? = nil,
+        link_local_ips: [String]? = nil,
+        mac_address: String? = nil,
+        priority: Int? = nil
+    ) {
         self.aliases = aliases
+        self.driver_opts = driver_opts
+        self.gw_priority = gw_priority
+        self.interface_name = interface_name
         self.ipv4_address = ipv4_address
+        self.ipv6_address = ipv6_address
+        self.link_local_ips = link_local_ips
+        self.mac_address = mac_address
+        self.priority = priority
     }
 }

--- a/Sources/Container-Compose/Codable Structs/ServiceNetwork.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceNetwork.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Service-level network options from Docker Compose map syntax.
+public struct ServiceNetwork: Codable, Hashable {
+    /// Network-scoped service aliases.
+    public let aliases: [String]?
+
+    /// Requested static IPv4 address.
+    public let ipv4_address: String?
+
+    public init(aliases: [String]? = nil, ipv4_address: String? = nil) {
+        self.aliases = aliases
+        self.ipv4_address = ipv4_address
+    }
+}

--- a/Tests/Container-Compose-StaticTests/NetworkConfigurationTests.swift
+++ b/Tests/Container-Compose-StaticTests/NetworkConfigurationTests.swift
@@ -77,7 +77,16 @@ struct NetworkConfigurationTests {
               backend:
                 aliases:
                   - app.local
+                driver_opts:
+                  com.docker.network.endpoint.expose: "true"
+                gw_priority: 10
+                interface_name: eth0
                 ipv4_address: 10.10.0.5
+                ipv6_address: 2001:3984:3989::10
+                link_local_ips:
+                  - fe80::1
+                mac_address: "02:42:72:98:65:08"
+                priority: 100
         networks:
           backend:
         """
@@ -88,7 +97,14 @@ struct NetworkConfigurationTests {
 
         #expect(app.networks == ["backend"])
         #expect(app.networkConfigurations?["backend"]?.aliases == ["app.local"])
+        #expect(app.networkConfigurations?["backend"]?.driver_opts?["com.docker.network.endpoint.expose"] == "true")
+        #expect(app.networkConfigurations?["backend"]?.gw_priority == 10)
+        #expect(app.networkConfigurations?["backend"]?.interface_name == "eth0")
         #expect(app.networkConfigurations?["backend"]?.ipv4_address == "10.10.0.5")
+        #expect(app.networkConfigurations?["backend"]?.ipv6_address == "2001:3984:3989::10")
+        #expect(app.networkConfigurations?["backend"]?.link_local_ips == ["fe80::1"])
+        #expect(app.networkConfigurations?["backend"]?.mac_address == "02:42:72:98:65:08")
+        #expect(app.networkConfigurations?["backend"]?.priority == 100)
     }
 
     @Test("Parse service network object syntax with null value")

--- a/Tests/Container-Compose-StaticTests/NetworkConfigurationTests.swift
+++ b/Tests/Container-Compose-StaticTests/NetworkConfigurationTests.swift
@@ -65,7 +65,53 @@ struct NetworkConfigurationTests {
         #expect(compose.services["app"]??.networks?.contains("frontend") == true)
         #expect(compose.services["app"]??.networks?.contains("backend") == true)
     }
-    
+
+    @Test("Parse service network object syntax")
+    func parseServiceNetworkObjectSyntax() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: myapp:latest
+            networks:
+              backend:
+                aliases:
+                  - app.local
+                ipv4_address: 10.10.0.5
+        networks:
+          backend:
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+        let app = try #require(compose.services["app"] ?? nil)
+
+        #expect(app.networks == ["backend"])
+        #expect(app.networkConfigurations?["backend"]?.aliases == ["app.local"])
+        #expect(app.networkConfigurations?["backend"]?.ipv4_address == "10.10.0.5")
+    }
+
+    @Test("Parse service network object syntax with null value")
+    func parseServiceNetworkObjectSyntaxWithNullValue() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          redis:
+            image: redis:alpine
+            networks:
+              netbridge:
+        networks:
+          netbridge:
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+        let redis = try #require(compose.services["redis"] ?? nil)
+
+        #expect(redis.networks == ["netbridge"])
+        #expect(redis.networkConfigurations?["netbridge"] == ServiceNetwork())
+    }
+
     @Test("Parse network with driver")
     func parseNetworkWithDriver() throws {
         let yaml = """
@@ -121,7 +167,25 @@ struct NetworkConfigurationTests {
         #expect(network.labels?["com.example.description"] == "Frontend Network")
         #expect(network.labels?["com.example.version"] == "1.0")
     }
-    
+
+    @Test("Parse network ipam subnets")
+    func parseNetworkIPAMSubnets() throws {
+        let yaml = """
+        internal: true
+        ipam:
+          config:
+            - subnet: 172.18.0.0/16
+            - subnet: fd00:abcd::/64
+        """
+
+        let decoder = YAMLDecoder()
+        let network = try decoder.decode(Network.self, from: yaml)
+
+        #expect(network.isInternal == true)
+        #expect(network.ipam?.ipv4Subnet == "172.18.0.0/16")
+        #expect(network.ipam?.ipv6Subnet == "fd00:abcd::/64")
+    }
+
     @Test("Multiple networks in compose")
     func multipleNetworksInCompose() throws {
         let yaml = """
@@ -187,4 +251,3 @@ struct NetworkConfigurationTests {
         #expect(compose.services["web"] != nil)
     }
 }
-


### PR DESCRIPTION
## Summary
- parse service-level networks map syntax into ServiceNetwork metadata
- preserve null service network entries as default ServiceNetwork values
- parse top-level network IPAM config and expose IPv4/IPv6 subnet helpers

## Notes
Split out of #85 so network parsing compatibility can be reviewed independently.

## Verification
- git diff --check
- swift test --filter NetworkConfigurationTests