### PR TITLE
Parse Compose runtime options

### DIFF
--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -80,6 +80,24 @@ public struct Service: Codable, Hashable {
     /// Mount container's root filesystem as read-only
     public let read_only: Bool?
 
+    /// Mount tmpfs paths inside the container
+    public let tmpfs: [String]?
+
+    /// Linux capabilities to add
+    public let cap_add: [String]?
+
+    /// Linux capabilities to drop
+    public let cap_drop: [String]?
+
+    /// Container ulimit settings
+    public let ulimits: [String: ServiceUlimit]?
+
+    /// Run an init process as PID 1
+    public let initProcess: Bool?
+
+    /// Security options such as no-new-privileges
+    public let security_opt: [String]?
+
     /// Working directory inside the container
     public let working_dir: String?
 
@@ -104,7 +122,7 @@ public struct Service: Codable, Hashable {
     // Defines custom coding keys to map YAML keys to Swift properties
     enum CodingKeys: String, CodingKey {
         case image, build, deploy, restart, healthcheck, volumes, environment, env_file, ports, command, depends_on, user,
-             container_name, networks, hostname, entrypoint, privileged, read_only, working_dir, configs, secrets, stdin_open, tty, platform
+             container_name, networks, hostname, entrypoint, privileged, read_only, tmpfs, cap_add, cap_drop, ulimits, initProcess = "init", security_opt, working_dir, configs, secrets, stdin_open, tty, platform
     }
     
     /// Public memberwise initializer for testing
@@ -127,6 +145,12 @@ public struct Service: Codable, Hashable {
         entrypoint: [String]? = nil,
         privileged: Bool? = nil,
         read_only: Bool? = nil,
+        tmpfs: [String]? = nil,
+        cap_add: [String]? = nil,
+        cap_drop: [String]? = nil,
+        ulimits: [String: ServiceUlimit]? = nil,
+        initProcess: Bool? = nil,
+        security_opt: [String]? = nil,
         working_dir: String? = nil,
         platform: String? = nil,
         configs: [ServiceConfig]? = nil,
@@ -153,6 +177,12 @@ public struct Service: Codable, Hashable {
         self.entrypoint = entrypoint
         self.privileged = privileged
         self.read_only = read_only
+        self.tmpfs = tmpfs
+        self.cap_add = cap_add
+        self.cap_drop = cap_drop
+        self.ulimits = ulimits
+        self.initProcess = initProcess
+        self.security_opt = security_opt
         self.working_dir = working_dir
         self.platform = platform
         self.configs = configs
@@ -212,12 +242,25 @@ public struct Service: Codable, Hashable {
 
         privileged = try container.decodeIfPresent(Bool.self, forKey: .privileged)
         read_only = try container.decodeIfPresent(Bool.self, forKey: .read_only)
+        tmpfs = try Self.decodeStringList(container, forKey: .tmpfs)
+        cap_add = try Self.decodeStringList(container, forKey: .cap_add)
+        cap_drop = try Self.decodeStringList(container, forKey: .cap_drop)
+        ulimits = try container.decodeIfPresent([String: ServiceUlimit].self, forKey: .ulimits)
+        initProcess = try container.decodeIfPresent(Bool.self, forKey: .initProcess)
+        security_opt = try Self.decodeStringList(container, forKey: .security_opt)
         working_dir = try container.decodeIfPresent(String.self, forKey: .working_dir)
         configs = try container.decodeIfPresent([ServiceConfig].self, forKey: .configs)
         secrets = try container.decodeIfPresent([ServiceSecret].self, forKey: .secrets)
         stdin_open = try container.decodeIfPresent(Bool.self, forKey: .stdin_open)
         tty = try container.decodeIfPresent(Bool.self, forKey: .tty)
         platform = try container.decodeIfPresent(String.self, forKey: .platform)
+    }
+
+    private static func decodeStringList(_ container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> [String]? {
+        if let string = try? container.decodeIfPresent(String.self, forKey: key) {
+            return [string]
+        }
+        return try container.decodeIfPresent([String].self, forKey: key)
     }
     
     /// Returns the services in topological order based on `depends_on` relationships.

--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -243,11 +243,11 @@ public struct Service: Codable, Hashable {
         privileged = try container.decodeIfPresent(Bool.self, forKey: .privileged)
         read_only = try container.decodeIfPresent(Bool.self, forKey: .read_only)
         tmpfs = try Self.decodeStringList(container, forKey: .tmpfs)
-        cap_add = try Self.decodeStringList(container, forKey: .cap_add)
-        cap_drop = try Self.decodeStringList(container, forKey: .cap_drop)
+        cap_add = try container.decodeIfPresent([String].self, forKey: .cap_add)
+        cap_drop = try container.decodeIfPresent([String].self, forKey: .cap_drop)
         ulimits = try container.decodeIfPresent([String: ServiceUlimit].self, forKey: .ulimits)
-        initProcess = try container.decodeIfPresent(Bool.self, forKey: .initProcess)
-        security_opt = try Self.decodeStringList(container, forKey: .security_opt)
+        initProcess = try Self.decodeBool(container, forKey: .initProcess)
+        security_opt = try container.decodeIfPresent([String].self, forKey: .security_opt)
         working_dir = try container.decodeIfPresent(String.self, forKey: .working_dir)
         configs = try container.decodeIfPresent([ServiceConfig].self, forKey: .configs)
         secrets = try container.decodeIfPresent([ServiceSecret].self, forKey: .secrets)
@@ -261,6 +261,40 @@ public struct Service: Codable, Hashable {
             return [string]
         }
         return try container.decodeIfPresent([String].self, forKey: key)
+    }
+
+    private static func decodeBool(_ container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> Bool? {
+        try container.decodeIfPresent(BoolOrString.self, forKey: key)?.value
+    }
+
+    private struct BoolOrString: Decodable {
+        let value: Bool
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let bool = try? container.decode(Bool.self) {
+                value = bool
+                return
+            }
+            if let string = try? container.decode(String.self) {
+                switch string.lowercased() {
+                case "true":
+                    value = true
+                case "false":
+                    value = false
+                default:
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Expected 'true' or 'false'."
+                    )
+                }
+                return
+            }
+            throw DecodingError.typeMismatch(
+                Bool.self,
+                DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected a boolean or string.")
+            )
+        }
     }
     
     /// Returns the services in topological order based on `depends_on` relationships.

--- a/Sources/Container-Compose/Codable Structs/ServiceUlimit.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceUlimit.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Docker Compose `ulimits` entry, preserving both scalar and soft/hard forms.
+public struct ServiceUlimit: Codable, Hashable {
+    public let value: String?
+    public let soft: String?
+    public let hard: String?
+
+    public init(value: String? = nil, soft: String? = nil, hard: String? = nil) {
+        self.value = value
+        self.soft = soft
+        self.hard = hard
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case value, soft, hard
+    }
+
+    public init(from decoder: Decoder) throws {
+        if let intValue = try? decoder.singleValueContainer().decode(Int.self) {
+            self.init(value: String(intValue))
+            return
+        }
+        if let stringValue = try? decoder.singleValueContainer().decode(String.self) {
+            self.init(value: stringValue)
+            return
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            soft: try Self.decodeScalar(container, forKey: .soft),
+            hard: try Self.decodeScalar(container, forKey: .hard)
+        )
+    }
+
+    private static func decodeScalar(_ container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> String? {
+        if let intValue = try? container.decodeIfPresent(Int.self, forKey: key) {
+            return String(intValue)
+        }
+        return try container.decodeIfPresent(String.self, forKey: key)
+    }
+}

--- a/Sources/Container-Compose/Codable Structs/ServiceUlimit.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceUlimit.swift
@@ -40,10 +40,14 @@ public struct ServiceUlimit: Codable, Hashable {
             return
         }
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.init(
-            soft: try Self.decodeScalar(container, forKey: .soft),
-            hard: try Self.decodeScalar(container, forKey: .hard)
-        )
+        let soft = try Self.decodeScalar(container, forKey: .soft)
+        let hard = try Self.decodeScalar(container, forKey: .hard)
+        guard soft != nil, hard != nil else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Ulimit object entries must include both 'soft' and 'hard'.")
+            )
+        }
+        self.init(soft: soft, hard: hard)
     }
 
     private static func decodeScalar(_ container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> String? {

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -179,6 +179,43 @@ struct DockerComposeParsingTests {
         
         #expect(compose.services["web"]??.depends_on?.contains("db") == true)
     }
+
+    @Test("Parse compose runtime options")
+    func parseComposeRuntimeOptions() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: alpine:latest
+            tmpfs:
+              - /run
+              - /tmp:size=64m
+            cap_add:
+              - NET_ADMIN
+            cap_drop: ALL
+            ulimits:
+              nofile:
+                soft: 1024
+                hard: 2048
+              nproc: 65535
+            init: true
+            security_opt:
+              - "no-new-privileges:true"
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+        let app = try #require(compose.services["app"] ?? nil)
+
+        #expect(app.tmpfs == ["/run", "/tmp:size=64m"])
+        #expect(app.cap_add == ["NET_ADMIN"])
+        #expect(app.cap_drop == ["ALL"])
+        #expect(app.ulimits?["nofile"]?.soft == "1024")
+        #expect(app.ulimits?["nofile"]?.hard == "2048")
+        #expect(app.ulimits?["nproc"]?.value == "65535")
+        #expect(app.initProcess == true)
+        #expect(app.security_opt == ["no-new-privileges:true"])
+    }
     
     @Test("Parse compose with build context")
     func parseComposeWithBuild() throws {

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -192,13 +192,14 @@ struct DockerComposeParsingTests {
               - /tmp:size=64m
             cap_add:
               - NET_ADMIN
-            cap_drop: ALL
+            cap_drop:
+              - ALL
             ulimits:
               nofile:
                 soft: 1024
                 hard: 2048
               nproc: 65535
-            init: true
+            init: "true"
             security_opt:
               - "no-new-privileges:true"
         """
@@ -215,6 +216,24 @@ struct DockerComposeParsingTests {
         #expect(app.ulimits?["nproc"]?.value == "65535")
         #expect(app.initProcess == true)
         #expect(app.security_opt == ["no-new-privileges:true"])
+    }
+
+    @Test("Compose ulimit object requires soft and hard")
+    func composeUlimitObjectRequiresSoftAndHard() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: alpine:latest
+            ulimits:
+              nofile:
+                soft: 1024
+        """
+
+        let decoder = YAMLDecoder()
+        #expect(throws: Error.self) {
+            try decoder.decode(DockerCompose.self, from: yaml)
+        }
     }
     
     @Test("Parse compose with build context")


### PR DESCRIPTION
## Summary
- parse tmpfs, cap_add, cap_drop, init, and security_opt service options
- preserve scalar and soft/hard ulimits through ServiceUlimit

## Notes
Split out of #85 so runtime option parsing can be reviewed independently. This only preserves parsed model data; it does not add container run behavior.

## Verification
- git diff --check
- swift test --filter DockerComposeParsingTests