### PR TITLE
Parse command and volume forms

### DIFF
--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -185,7 +185,7 @@ public struct Service: Codable, Hashable {
         if let cmdArray = try? container.decodeIfPresent([String].self, forKey: .command) {
             command = cmdArray
         } else if let cmdString = try? container.decodeIfPresent(String.self, forKey: .command) {
-            command = composeShellSplit(cmdString)
+            command = try composeShellSplit(cmdString)
         } else {
             command = nil
         }
@@ -205,7 +205,7 @@ public struct Service: Codable, Hashable {
         if let entrypointArray = try? container.decodeIfPresent([String].self, forKey: .entrypoint) {
             entrypoint = entrypointArray
         } else if let entrypointString = try? container.decodeIfPresent(String.self, forKey: .entrypoint) {
-            entrypoint = composeShellSplit(entrypointString)
+            entrypoint = try composeShellSplit(entrypointString)
         } else {
             entrypoint = nil
         }

--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -176,7 +176,7 @@ public struct Service: Codable, Hashable {
 
         restart = try container.decodeIfPresent(String.self, forKey: .restart)
         healthcheck = try container.decodeIfPresent(Healthcheck.self, forKey: .healthcheck)
-        volumes = try container.decodeIfPresent([String].self, forKey: .volumes)
+        volumes = try Self.decodeVolumeList(container, forKey: .volumes)
         environment = try container.decodeIfPresent([String: String].self, forKey: .environment)
         env_file = try container.decodeIfPresent([String].self, forKey: .env_file)
         ports = try container.decodeIfPresent([String].self, forKey: .ports)
@@ -185,7 +185,7 @@ public struct Service: Codable, Hashable {
         if let cmdArray = try? container.decodeIfPresent([String].self, forKey: .command) {
             command = cmdArray
         } else if let cmdString = try? container.decodeIfPresent(String.self, forKey: .command) {
-            command = [cmdString]
+            command = composeShellSplit(cmdString)
         } else {
             command = nil
         }
@@ -205,7 +205,7 @@ public struct Service: Codable, Hashable {
         if let entrypointArray = try? container.decodeIfPresent([String].self, forKey: .entrypoint) {
             entrypoint = entrypointArray
         } else if let entrypointString = try? container.decodeIfPresent(String.self, forKey: .entrypoint) {
-            entrypoint = [entrypointString]
+            entrypoint = composeShellSplit(entrypointString)
         } else {
             entrypoint = nil
         }
@@ -218,6 +218,12 @@ public struct Service: Codable, Hashable {
         stdin_open = try container.decodeIfPresent(Bool.self, forKey: .stdin_open)
         tty = try container.decodeIfPresent(Bool.self, forKey: .tty)
         platform = try container.decodeIfPresent(String.self, forKey: .platform)
+    }
+
+    private static func decodeVolumeList(_ container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> [String]? {
+        guard container.contains(key) else { return nil }
+        let volumes = try container.decode([ServiceVolume].self, forKey: key)
+        return volumes.map(\.mount)
     }
     
     /// Returns the services in topological order based on `depends_on` relationships.

--- a/Sources/Container-Compose/Codable Structs/ServiceVolume.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceVolume.swift
@@ -29,18 +29,32 @@ public struct ServiceVolume: Codable, Hashable {
         }
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decodeIfPresent(String.self, forKey: .type) ?? "volume"
+        let type = try container.decode(String.self, forKey: .type)
         let source = try container.decodeIfPresent(String.self, forKey: .source)
         let target = try container.decode(String.self, forKey: .target)
-        let readOnly = try container.decodeIfPresent(Bool.self, forKey: .read_only) ?? false
+        let readOnly = try Self.decodeBool(container, forKey: .read_only) ?? false
         let consistency = try container.decodeIfPresent(String.self, forKey: .consistency)
+        let bind = try container.decodeIfPresent(BindOptions.self, forKey: .bind)
+        let volume = try container.decodeIfPresent(VolumeOptions.self, forKey: .volume)
 
         var options: [String] = []
         if readOnly {
             options.append("ro")
         }
+        if let selinux = bind?.selinux, !selinux.isEmpty {
+            options.append(selinux)
+        }
+        if let propagation = bind?.propagation, !propagation.isEmpty {
+            options.append(propagation)
+        }
         if let consistency, !consistency.isEmpty {
             options.append(consistency)
+        }
+        if volume?.nocopy == true {
+            options.append("nocopy")
+        }
+        if !readOnly, !options.isEmpty {
+            options.insert("rw", at: 0)
         }
         let suffix = options.isEmpty ? "" : ":\(options.joined(separator: ","))"
 
@@ -71,7 +85,7 @@ public struct ServiceVolume: Codable, Hashable {
             throw DecodingError.dataCorruptedError(
                 forKey: .type,
                 in: container,
-                debugDescription: "Unsupported service volume type '\(type)'."
+                debugDescription: "Unsupported service volume type '\(type)'. Only 'bind' and 'volume' can be represented as mount strings."
             )
         }
     }
@@ -87,5 +101,59 @@ public struct ServiceVolume: Codable, Hashable {
         case target
         case read_only
         case consistency
+        case bind
+        case volume
+    }
+
+    private struct BindOptions: Codable, Hashable {
+        let selinux: String?
+        let propagation: String?
+    }
+
+    private struct VolumeOptions: Decodable, Hashable {
+        let nocopy: Bool?
+
+        enum CodingKeys: String, CodingKey {
+            case nocopy
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            nocopy = try ServiceVolume.decodeBool(container, forKey: .nocopy)
+        }
+    }
+
+    private static func decodeBool<K>(_ container: KeyedDecodingContainer<K>, forKey key: K) throws -> Bool? where K: CodingKey {
+        try container.decodeIfPresent(BoolOrString.self, forKey: key)?.value
+    }
+
+    private struct BoolOrString: Decodable {
+        let value: Bool
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let bool = try? container.decode(Bool.self) {
+                value = bool
+                return
+            }
+            if let string = try? container.decode(String.self) {
+                switch string.lowercased() {
+                case "true":
+                    value = true
+                case "false":
+                    value = false
+                default:
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Expected 'true' or 'false'."
+                    )
+                }
+                return
+            }
+            throw DecodingError.typeMismatch(
+                Bool.self,
+                DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected a boolean or string.")
+            )
+        }
     }
 }

--- a/Sources/Container-Compose/Codable Structs/ServiceVolume.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceVolume.swift
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+public struct ServiceVolume: Codable, Hashable {
+    public let mount: String
+
+    public init(_ mount: String) {
+        self.mount = mount
+    }
+
+    public init(from decoder: Decoder) throws {
+        let singleValue = try decoder.singleValueContainer()
+        if let mount = try? singleValue.decode(String.self) {
+            self.mount = mount
+            return
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decodeIfPresent(String.self, forKey: .type) ?? "volume"
+        let source = try container.decodeIfPresent(String.self, forKey: .source)
+        let target = try container.decode(String.self, forKey: .target)
+        let readOnly = try container.decodeIfPresent(Bool.self, forKey: .read_only) ?? false
+        let consistency = try container.decodeIfPresent(String.self, forKey: .consistency)
+
+        var options: [String] = []
+        if readOnly {
+            options.append("ro")
+        }
+        if let consistency, !consistency.isEmpty {
+            options.append(consistency)
+        }
+        let suffix = options.isEmpty ? "" : ":\(options.joined(separator: ","))"
+
+        switch type {
+        case "bind":
+            guard let source, !source.isEmpty else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .source,
+                    in: container,
+                    debugDescription: "Bind volume must define 'source'."
+                )
+            }
+            mount = "\(source):\(target)\(suffix)"
+        case "volume":
+            guard let source, !source.isEmpty else {
+                guard options.isEmpty else {
+                    throw DecodingError.dataCorruptedError(
+                        forKey: .source,
+                        in: container,
+                        debugDescription: "Anonymous volumes cannot express mount options in short syntax."
+                    )
+                }
+                mount = target
+                return
+            }
+            mount = "\(source):\(target)\(suffix)"
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unsupported service volume type '\(type)'."
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(mount)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case source
+        case target
+        case read_only
+        case consistency
+    }
+}

--- a/Sources/Container-Compose/Helper Functions.swift
+++ b/Sources/Container-Compose/Helper Functions.swift
@@ -60,7 +60,21 @@ public func loadEnvFile(path: String) -> [String: String] {
     return envVars
 }
 
-public func composeShellSplit(_ input: String) -> [String] {
+enum ComposeShellSplitError: Error, LocalizedError {
+    case trailingEscape
+    case unterminatedQuote
+
+    var errorDescription: String? {
+        switch self {
+        case .trailingEscape:
+            return "Command string ends with an unfinished escape."
+        case .unterminatedQuote:
+            return "Command string contains an unterminated quote."
+        }
+    }
+}
+
+public func composeShellSplit(_ input: String) throws -> [String] {
     enum Quote {
         case single
         case double
@@ -119,7 +133,10 @@ public func composeShellSplit(_ input: String) -> [String] {
     }
 
     if escaping {
-        current.append("\\")
+        throw ComposeShellSplitError.trailingEscape
+    }
+    if quote != nil {
+        throw ComposeShellSplitError.unterminatedQuote
     }
     if tokenStarted {
         tokens.append(current)

--- a/Sources/Container-Compose/Helper Functions.swift
+++ b/Sources/Container-Compose/Helper Functions.swift
@@ -60,6 +60,73 @@ public func loadEnvFile(path: String) -> [String: String] {
     return envVars
 }
 
+public func composeShellSplit(_ input: String) -> [String] {
+    enum Quote {
+        case single
+        case double
+    }
+
+    var tokens: [String] = []
+    var current = ""
+    var quote: Quote?
+    var escaping = false
+    var tokenStarted = false
+
+    for character in input {
+        if escaping {
+            current.append(character)
+            tokenStarted = true
+            escaping = false
+            continue
+        }
+
+        switch quote {
+        case .single:
+            if character == "'" {
+                quote = nil
+            } else {
+                current.append(character)
+            }
+        case .double:
+            if character == "\"" {
+                quote = nil
+            } else if character == "\\" {
+                escaping = true
+            } else {
+                current.append(character)
+            }
+        case nil:
+            if character == "\\" {
+                escaping = true
+                tokenStarted = true
+            } else if character == "'" {
+                quote = .single
+                tokenStarted = true
+            } else if character == "\"" {
+                quote = .double
+                tokenStarted = true
+            } else if character.isWhitespace {
+                if tokenStarted {
+                    tokens.append(current)
+                    current = ""
+                    tokenStarted = false
+                }
+            } else {
+                current.append(character)
+                tokenStarted = true
+            }
+        }
+    }
+
+    if escaping {
+        current.append("\\")
+    }
+    if tokenStarted {
+        tokens.append(current)
+    }
+    return tokens
+}
+
 /// Resolves environment variables within a string (e.g., ${VAR:-default}, ${VAR:?error}).
 /// This function supports default values and error-on-missing variable syntax.
 /// - Parameters:

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -99,6 +99,36 @@ struct DockerComposeParsingTests {
         #expect(compose.services["db"]??.volumes?.count == 1)
         #expect(compose.services["db"]??.volumes?.first == "db-data:/var/lib/postgresql/data")
     }
+
+    @Test("Parse compose long-form volume options")
+    func parseComposeLongFormVolumeOptions() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: alpine:latest
+            volumes:
+              - type: bind
+                source: ./data
+                target: /data
+                read_only: "true"
+                bind:
+                  selinux: z
+                  propagation: rslave
+              - type: volume
+                source: cache
+                target: /cache
+                volume:
+                  nocopy: "true"
+        volumes:
+          cache:
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+
+        #expect(compose.services["app"]??.volumes == ["./data:/data:ro,z,rslave", "cache:/cache:rw,nocopy"])
+    }
     
     @Test("Parse compose with networks")
     func parseComposeWithNetworks() throws {
@@ -250,6 +280,22 @@ struct DockerComposeParsingTests {
 
         #expect(compose.services["app"]??.command == ["--enable-debug-command", "yes", "--save", ""])
         #expect(compose.services["shell"]??.entrypoint == ["sh", "-lc", "echo hello world"])
+    }
+
+    @Test("Malformed compose command string should fail")
+    func malformedComposeCommandStringShouldFail() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: alpine:latest
+            command: "sh -lc 'echo hello"
+        """
+
+        let decoder = YAMLDecoder()
+        #expect(throws: Error.self) {
+            try decoder.decode(DockerCompose.self, from: yaml)
+        }
     }
     
     @Test("Parse compose with restart policy")

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -229,8 +229,27 @@ struct DockerComposeParsingTests {
         let decoder = YAMLDecoder()
         let compose = try decoder.decode(DockerCompose.self, from: yaml)
         
-        #expect(compose.services["app"]??.command?.count == 1)
-        #expect(compose.services["app"]??.command?.first == "echo hello")
+        #expect(compose.services["app"]??.command == ["echo", "hello"])
+    }
+
+    @Test("Parse compose command string with quotes")
+    func parseComposeCommandStringWithQuotes() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: alpine:latest
+            command: --enable-debug-command yes --save ""
+          shell:
+            image: alpine:latest
+            entrypoint: sh -lc "echo hello world"
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+
+        #expect(compose.services["app"]??.command == ["--enable-debug-command", "yes", "--save", ""])
+        #expect(compose.services["shell"]??.entrypoint == ["sh", "-lc", "echo hello world"])
     }
     
     @Test("Parse compose with restart policy")


### PR DESCRIPTION
## Summary
- split Compose command and entrypoint string forms with quote-aware shell-style tokenization
- decode long-form service volume entries into the existing mount string model

## Notes
Split out of #85 because command string tokenization is the most behavior-visible parser change.

## Verification
- git diff --check
- swift test --filter DockerComposeParsingTests