### PR TITLE
fix: added new direct drivers for network volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,49 @@ container-compose up
 
 You may need to provide a path to your `docker-compose.yml` and `.env` file as arguments.
 
+## Utilities
+
+For guest-kernel swaps when testing SMB/NFS support with Apple `container`, this repo includes:
+
+```sh
+./scripts/setup-container-kernel.sh --binary /path/to/vmlinux --force
+```
+
+That script installs the kernel with `container system kernel set`, restarts the `container` services, and prints the configured kernel path before and after the change.
+Omit `--force` to be prompted before replacing the configured kernel, or add `--dry-run` to preview the commands without changing your system.
+After changing the default kernel, recreate existing test containers so their lightweight VMs boot with the new kernel.
+
+### Building an SMB-ready guest kernel
+
+SMB/CIFS mounts require a guest kernel with CIFS support enabled. Apple `containerization` includes that support in `kernel/config-arm64` as of apple/containerization#681, and Kata's common filesystem fragment also enables CIFS support.
+
+Build a compatible kernel from `apple/containerization`:
+
+```sh
+git clone https://github.com/apple/containerization.git
+cd containerization/kernel
+
+# Optional sanity check: the config should include CIFS and NFS support.
+grep -E 'CONFIG_(CIFS|NFS_FS)=' config-arm64
+
+make
+```
+
+The build uses Apple `container` to build inside a containerized toolchain. When it completes, the kernel artifact is:
+
+```sh
+containerization/kernel/vmlinux
+```
+
+Install that kernel for Apple `container` with this repo's helper:
+
+```sh
+cd /path/to/Container-Compose
+./scripts/setup-container-kernel.sh --binary /path/to/containerization/kernel/vmlinux --force
+```
+
+Then recreate existing test containers so their lightweight VMs boot with the new kernel.
+
 ## Contributing
 
 Contributions are welcome! Please open issues or submit pull requests to help improve this project.

--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -103,6 +103,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
     private var environmentVariables: [String: String] = [:]
     private var containerIps: [String: String] = [:]
     private var containerConsoleColors: [String: NamedColor] = [:]
+    private var composeVolumes: [String: Volume] = [:]
 
     private static let availableContainerConsoleColors: Set<NamedColor> = [
         .blue, .cyan, .magenta, .lightBlack, .lightBlue, .lightCyan, .lightYellow, .yellow, .lightGreen, .green,
@@ -120,6 +121,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         // Decode the YAML file into the DockerCompose struct
         let dockerComposeString = String(data: yamlData, encoding: .utf8)!
         let dockerCompose = try YAMLDecoder().decode(DockerCompose.self, from: dockerComposeString)
+        composeVolumes = dockerCompose.volumes?.compactMapValues { $0 } ?? [:]
 
         // Load environment variables from .env file
         environmentVariables = loadEnvFile(path: envFilePath)
@@ -175,7 +177,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             print("\n--- Processing Volumes ---")
             for (volumeName, volumeConfig) in volumes {
                 guard let volumeConfig else { continue }
-                await createVolumeHardLink(name: volumeName, config: volumeConfig)
+                try await createVolume(name: volumeName, config: volumeConfig)
             }
             print("--- Volumes Processed ---\n")
         }
@@ -274,17 +276,60 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         }
     }
 
-    private func createVolumeHardLink(name volumeName: String, config volumeConfig: Volume) async {
-        guard let projectName else { return }
-        let actualVolumeName = volumeConfig.name ?? volumeName  // Use explicit name or key as name
+    private func createVolume(name volumeName: String, config volumeConfig: Volume) async throws {
+        let actualVolumeName = effectiveVolumeName(for: volumeName)
+        let normalizedVolume = VolumeConfigurationNormalizer.normalized(from: volumeConfig)
 
-        let volumeUrl = URL.homeDirectory.appending(path: ".containers/Volumes/\(projectName)/\(actualVolumeName)")
-        let volumePath = volumeUrl.path(percentEncoded: false)
+        if let externalVolume = volumeConfig.external, externalVolume.isExternal {
+            print("Info: Volume '\(volumeName)' is declared as external.")
+            print("This tool assumes external volume '\(externalVolume.name ?? actualVolumeName)' already exists and will not attempt to create it.")
+            return
+        }
 
-        print(
-            "Warning: Volume source '\(actualVolumeName)' appears to be a named volume reference. The 'container' tool does not support named volume references in 'container run -v' command. Linking to \(volumePath) instead."
-        )
-        try? fileManager.createDirectory(atPath: volumePath, withIntermediateDirectories: true)
+        do {
+            let existingVolume = try await ClientVolume.inspect(actualVolumeName)
+            if existingVolume.driver != normalizedVolume.driver || existingVolume.options != normalizedVolume.driverOpts {
+                print(
+                    "Error: Volume '\(volumeName)' already exists as '\(actualVolumeName)', but its configuration does not match the Compose file."
+                )
+                print(
+                    "Existing driver/options: \(existingVolume.driver) \(existingVolume.options). Expected: \(normalizedVolume.driver) \(normalizedVolume.driverOpts)."
+                )
+                print("Delete the existing volume and re-run `container-compose up` to recreate it with the correct settings.")
+                throw ComposeError.volumeConfigurationMismatch(volumeName)
+            } else {
+                print("Volume '\(volumeName)' already exists as '\(actualVolumeName)'")
+            }
+            return
+        } catch {
+            // Fall through to creation.
+        }
+
+        do {
+            let labels = volumeConfig.labels ?? [:]
+            _ = try await ClientVolume.create(
+                name: actualVolumeName,
+                driver: normalizedVolume.driver,
+                driverOpts: normalizedVolume.driverOpts,
+                labels: labels
+            )
+            print("Created volume: \(volumeName) (Actual name: \(actualVolumeName), Driver: \(normalizedVolume.driver))")
+        } catch {
+            print("Error: Failed to create volume '\(volumeName)' as '\(actualVolumeName)': \(error.localizedDescription)")
+            throw error
+        }
+    }
+
+    private func effectiveVolumeName(for volumeName: String) -> String {
+        guard let config = composeVolumes[volumeName] else {
+            return volumeName
+        }
+
+        if let external = config.external, external.isExternal {
+            return external.name ?? config.name ?? volumeName
+        }
+
+        return config.name ?? volumeName
     }
 
     private func setupNetwork(name networkName: String, config networkConfig: Network?) async throws {
@@ -688,18 +733,21 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
     private func configVolume(_ volume: String) async throws -> [String] {
         let resolvedVolume = resolveVariable(volume, with: environmentVariables)
 
-        var runCommandArgs: [String] = []
-
-        // Parse the volume string: destination[:mode]
+        // Parse the volume string: source:destination[:mode] or destination for anonymous volumes.
         let components = resolvedVolume.split(separator: ":", maxSplits: 2).map(String.init)
 
+        if components.count == 1 {
+            return ["-v", resolvedVolume]
+        }
+
         guard components.count >= 2 else {
-            print("Warning: Volume entry '\(resolvedVolume)' has an invalid format (expected 'source:destination'). Skipping.")
+            print("Warning: Volume entry '\(resolvedVolume)' has an invalid format. Skipping.")
             return []
         }
 
         let source = components[0]
         let destination = components[1]
+        let mode = components.count == 3 ? components[2] : nil
 
         // Check if the source looks like a host path (contains '/' or starts with '.')
         // This heuristic helps distinguish bind mounts from named volume references.
@@ -707,14 +755,12 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             // This is likely a bind mount (local path to container path)
             var isDirectory: ObjCBool = false
             // Ensure the path is absolute or relative to the current directory for FileManager
-            let fullHostPath = (source.starts(with: "/") || source.starts(with: "~")) ? source : (cwd + "/" + source)
+            let expandedSource = NSString(string: source).expandingTildeInPath
+            let fullHostPath = source.starts(with: "/") || source.starts(with: "~") ? expandedSource : (cwd + "/" + source)
 
             if fileManager.fileExists(atPath: fullHostPath, isDirectory: &isDirectory) {
                 if isDirectory.boolValue {
-                    // Host path exists and is a directory, add the volume
-                    runCommandArgs.append("-v")
-                    // Reconstruct the volume string without mode, ensuring it's source:destination
-                    runCommandArgs.append("\(source):\(destination)")  // Use original source for command argument
+                    return ["-v", resolvedVolume]
                 } else {
                     // Host path exists but is a file
                     print("Warning: Volume mount source '\(source)' is a file. The 'container' tool does not support direct file mounts. Skipping this volume.")
@@ -724,32 +770,23 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
                 do {
                     try fileManager.createDirectory(atPath: fullHostPath, withIntermediateDirectories: true, attributes: nil)
                     print("Info: Created missing host directory for volume: \(fullHostPath)")
-                    runCommandArgs.append("-v")
-                    runCommandArgs.append("\(source):\(destination)")  // Use original source for command argument
+                    return ["-v", resolvedVolume]
                 } catch {
                     print("Error: Could not create host directory '\(fullHostPath)' for volume '\(resolvedVolume)': \(error.localizedDescription). Skipping this volume.")
                 }
             }
         } else {
-            guard let projectName else { return [] }
-            let volumeUrl = URL.homeDirectory.appending(path: ".containers/Volumes/\(projectName)/\(source)")
-            let volumePath = volumeUrl.path(percentEncoded: false)
-
-            let destinationUrl = URL(fileURLWithPath: destination).deletingLastPathComponent()
-            let destinationPath = destinationUrl.path(percentEncoded: false)
-
-            print(
-                "Warning: Volume source '\(source)' appears to be a named volume reference. The 'container' tool does not support named volume references in 'container run -v' command. Linking to \(volumePath) instead."
-            )
-            try fileManager.createDirectory(atPath: volumePath, withIntermediateDirectories: true)
-
-            // Host path exists and is a directory, add the volume
-            runCommandArgs.append("-v")
-            // Reconstruct the volume string without mode, ensuring it's source:destination
-            runCommandArgs.append("\(volumePath):\(destinationPath)")  // Use original source for command argument
+            let actualSource = effectiveVolumeName(for: source)
+            let volumeArgument: String
+            if let mode, !mode.isEmpty {
+                volumeArgument = "\(actualSource):\(destination):\(mode)"
+            } else {
+                volumeArgument = "\(actualSource):\(destination)"
+            }
+            return ["-v", volumeArgument]
         }
 
-        return runCommandArgs
+        return []
     }
 }
 
@@ -783,9 +820,14 @@ extension ComposeUp {
             process.standardOutput = stdoutPipe
             process.standardError = stderrPipe
 
-            process.environment = ProcessInfo.processInfo.environment.merging([
-                "PATH": "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-            ]) { _, new in new }
+            let defaultSearchPath = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+            var environment = ProcessInfo.processInfo.environment
+            if let inheritedPath = environment["PATH"], !inheritedPath.isEmpty {
+                environment["PATH"] = "\(inheritedPath):\(defaultSearchPath)"
+            } else {
+                environment["PATH"] = defaultSearchPath
+            }
+            process.environment = environment
 
             let stdoutHandle = stdoutPipe.fileHandleForReading
             let stderrHandle = stderrPipe.fileHandleForReading

--- a/Sources/Container-Compose/Errors.swift
+++ b/Sources/Container-Compose/Errors.swift
@@ -39,6 +39,7 @@ public enum YamlError: Error, LocalizedError {
 public enum ComposeError: Error, LocalizedError {
     case imageNotFound(String)
     case invalidProjectName
+    case volumeConfigurationMismatch(String)
 
     public var errorDescription: String? {
         switch self {
@@ -46,6 +47,8 @@ public enum ComposeError: Error, LocalizedError {
             return "Service \(name) must define either 'image' or 'build'."
         case .invalidProjectName:
             return "Could not find project name."
+        case .volumeConfigurationMismatch(let name):
+            return "Volume \(name) already exists with a different configuration."
         }
     }
 }

--- a/Sources/Container-Compose/VolumeConfiguration.swift
+++ b/Sources/Container-Compose/VolumeConfiguration.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+struct NormalizedVolumeConfiguration: Equatable {
+    let driver: String
+    let driverOpts: [String: String]
+}
+
+enum VolumeConfigurationNormalizer {
+    static func normalized(from volumeConfig: Volume) -> NormalizedVolumeConfiguration {
+        let driver = volumeConfig.driver ?? "local"
+        let driverOpts = volumeConfig.driver_opts ?? [:]
+
+        guard driver == "local", let type = driverOpts["type"]?.lowercased() else {
+            return NormalizedVolumeConfiguration(driver: driver, driverOpts: driverOpts)
+        }
+
+        switch type {
+        case "cifs", "smb":
+            return NormalizedVolumeConfiguration(driver: "smb", driverOpts: normalizeNetworkDriverOptions(driverOpts))
+        case "nfs":
+            return NormalizedVolumeConfiguration(driver: "nfs", driverOpts: normalizeNetworkDriverOptions(driverOpts))
+        default:
+            return NormalizedVolumeConfiguration(driver: driver, driverOpts: driverOpts)
+        }
+    }
+
+    private static func normalizeNetworkDriverOptions(_ driverOpts: [String: String]) -> [String: String] {
+        var normalized = driverOpts
+
+        if let device = normalized.removeValue(forKey: "device") {
+            normalized["share"] = device
+        }
+
+        if let optionString = normalized.removeValue(forKey: "o") {
+            for rawOption in optionString.split(separator: ",").map(String.init) where !rawOption.isEmpty {
+                let parts = rawOption.split(separator: "=", maxSplits: 1).map(String.init)
+                if parts.count == 2 {
+                    normalized[parts[0]] = parts[1]
+                } else {
+                    normalized[rawOption] = ""
+                }
+            }
+        }
+
+        normalized.removeValue(forKey: "type")
+        return normalized
+    }
+}

--- a/Tests/Container-Compose-DynamicTests/ComposeUpTests.swift
+++ b/Tests/Container-Compose-DynamicTests/ComposeUpTests.swift
@@ -322,6 +322,51 @@ struct ComposeUpTests {
         
         try? await stopInstance(location: project.base)
     }
+
+    @Test("Test compose up uses explicit top-level volume name")
+    func testComposeUpUsesTopLevelVolumeName() async throws {
+        let volumeName = "compose-volume-\(UUID().uuidString.lowercased())"
+        let yaml = """
+            version: "3.8"
+            services:
+                app:
+                    image: nginx:alpine
+                    volumes:
+                        - app-data:/usr/share/nginx/html
+            volumes:
+                app-data:
+                    name: \(volumeName)
+            """
+
+        let project = try DockerComposeYamlFiles.copyYamlToTemporaryLocation(yaml: yaml)
+
+        var composeUp = try ComposeUp.parse(["-d", "--cwd", project.base.path(percentEncoded: false)])
+        try await composeUp.run()
+
+        let containers = try await ContainerClient().list()
+            .filter {
+                $0.configuration.id.contains(project.name)
+            }
+
+        guard let appContainer = containers.first(where: { $0.configuration.id == "\(project.name)-app" }) else {
+            throw Errors.containerNotFound
+        }
+
+        #expect(appContainer.status == .running)
+        #expect(appContainer.configuration.mounts.count == 1)
+        #expect(appContainer.configuration.mounts.first?.volumeName == volumeName)
+        #expect(appContainer.configuration.mounts.first?.destination == "/usr/share/nginx/html")
+
+        let createdVolume = try await ClientVolume.inspect(volumeName)
+        #expect(createdVolume.name == volumeName)
+        #expect(createdVolume.driver == "local")
+
+        var composeDown = try ComposeDown.parse(["--cwd", project.base.path(percentEncoded: false)])
+        try await composeDown.run()
+
+        try? await ClientVolume.delete(name: volumeName)
+        try? await stopInstance(location: project.base)
+    }
     
     // A locally-built image whose reference contains a `/` (e.g. `myorg/foo:local`)
     // must not trigger a registry pull when referenced from a compose file.

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -99,6 +99,123 @@ struct DockerComposeParsingTests {
         #expect(compose.services["db"]??.volumes?.count == 1)
         #expect(compose.services["db"]??.volumes?.first == "db-data:/var/lib/postgresql/data")
     }
+
+    @Test("Parse compose with SMB/NFS volume configuration")
+    func parseComposeWithNetworkVolumes() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: alpine:latest
+            volumes:
+              - media-share:/media
+              - backups:/backups:ro
+        volumes:
+          media-share:
+            driver: smb
+            driver_opts:
+              share: //fileserver/media
+              username: mediauser
+          backups:
+            driver: nfs
+            name: remote-backups
+            driver_opts:
+              share: nas.local:/exports/backups
+              vers: "4.1"
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+
+        #expect(compose.volumes?["media-share"]??.driver == "smb")
+        #expect(compose.volumes?["media-share"]??.driver_opts?["share"] == "//fileserver/media")
+        #expect(compose.volumes?["backups"]??.driver == "nfs")
+        #expect(compose.volumes?["backups"]??.name == "remote-backups")
+        #expect(compose.volumes?["backups"]??.driver_opts?["share"] == "nas.local:/exports/backups")
+        #expect(compose.services["app"]??.volumes == ["media-share:/media", "backups:/backups:ro"])
+    }
+
+    @Test("Normalize direct SMB and NFS volume drivers")
+    func normalizeDirectNetworkVolumeDrivers() {
+        let smb = Volume(
+            driver: "smb",
+            driver_opts: [
+                "share": "//fileserver/media",
+                "username": "mediauser",
+            ]
+        )
+        let nfs = Volume(
+            driver: "nfs",
+            driver_opts: [
+                "share": "nas.local:/exports/backups",
+                "vers": "4.1",
+            ]
+        )
+
+        #expect(
+            VolumeConfigurationNormalizer.normalized(from: smb) == NormalizedVolumeConfiguration(
+                driver: "smb",
+                driverOpts: [
+                    "share": "//fileserver/media",
+                    "username": "mediauser",
+                ]
+            )
+        )
+        #expect(
+            VolumeConfigurationNormalizer.normalized(from: nfs) == NormalizedVolumeConfiguration(
+                driver: "nfs",
+                driverOpts: [
+                    "share": "nas.local:/exports/backups",
+                    "vers": "4.1",
+                ]
+            )
+        )
+    }
+
+    @Test("Normalize Docker-style CIFS and NFS volume options")
+    func normalizeDockerStyleNetworkVolumeOptions() {
+        let cifs = Volume(
+            driver: "local",
+            driver_opts: [
+                "type": "cifs",
+                "device": "//fileserver/media",
+                "o": "username=mediauser,password=secret,vers=3.0,mfsymlinks",
+            ]
+        )
+        let nfs = Volume(
+            driver: "local",
+            driver_opts: [
+                "type": "nfs",
+                "device": "nas.local:/exports/backups",
+                "o": "addr=nas.local,vers=4.1,proto=tcp,nolock",
+            ]
+        )
+
+        #expect(
+            VolumeConfigurationNormalizer.normalized(from: cifs) == NormalizedVolumeConfiguration(
+                driver: "smb",
+                driverOpts: [
+                    "share": "//fileserver/media",
+                    "username": "mediauser",
+                    "password": "secret",
+                    "vers": "3.0",
+                    "mfsymlinks": "",
+                ]
+            )
+        )
+        #expect(
+            VolumeConfigurationNormalizer.normalized(from: nfs) == NormalizedVolumeConfiguration(
+                driver: "nfs",
+                driverOpts: [
+                    "share": "nas.local:/exports/backups",
+                    "addr": "nas.local",
+                    "vers": "4.1",
+                    "proto": "tcp",
+                    "nolock": "",
+                ]
+            )
+        )
+    }
     
     @Test("Parse compose with networks")
     func parseComposeWithNetworks() throws {

--- a/scripts/setup-container-kernel.sh
+++ b/scripts/setup-container-kernel.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_NAME
+
+KERNEL_BINARY=""
+FORCE=0
+DRY_RUN=0
+SKIP_RESTART=0
+
+usage() {
+  cat <<EOF
+Usage:
+  ${SCRIPT_NAME} --binary /path/to/vmlinux [--force] [--dry-run] [--skip-restart]
+
+Options:
+  --binary <path>   Path to the guest kernel binary to install.
+  --force           Do not prompt before replacing the configured kernel.
+  --dry-run         Print the commands that would run without changing anything.
+  --skip-restart    Set the kernel but do not restart container services.
+  -h, --help        Show this help message.
+EOF
+}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+run() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '+'
+    printf ' %q' "$@"
+    printf '\n'
+    return 0
+  fi
+
+  "$@"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+print_kernel_state() {
+  local label="$1"
+
+  log ""
+  log "${label}:"
+  if ! run container system property get kernel.binaryPath; then
+    die "could not read container kernel configuration"
+  fi
+}
+
+confirm_kernel_swap() {
+  [[ "$FORCE" -eq 1 ]] && return 0
+
+  log ""
+  log "This will set the default Apple container guest kernel to:"
+  log "  ${KERNEL_BINARY}"
+  log ""
+  log "Existing containers may need to be recreated before they use the new kernel."
+  read -r -p "Continue? [y/N] " reply
+
+  case "$reply" in
+    [Yy] | [Yy][Ee][Ss]) ;;
+    *) die "kernel swap cancelled" ;;
+  esac
+}
+
+parse_args() {
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --binary)
+        [[ "$#" -ge 2 ]] || die "--binary requires a path"
+        KERNEL_BINARY="$2"
+        shift 2
+        ;;
+      --force)
+        FORCE=1
+        shift
+        ;;
+      --dry-run)
+        DRY_RUN=1
+        shift
+        ;;
+      --skip-restart)
+        SKIP_RESTART=1
+        shift
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *)
+        die "unknown argument: $1"
+        ;;
+    esac
+  done
+}
+
+main() {
+  parse_args "$@"
+
+  require_command container
+
+  [[ -n "$KERNEL_BINARY" ]] || die "missing required --binary path"
+  [[ -f "$KERNEL_BINARY" ]] || die "kernel binary does not exist: $KERNEL_BINARY"
+  [[ -r "$KERNEL_BINARY" ]] || die "kernel binary is not readable: $KERNEL_BINARY"
+
+  print_kernel_state "Kernel configuration before change"
+  confirm_kernel_swap
+
+  log ""
+  log "Installing guest kernel..."
+  kernel_set_args=(container system kernel set --binary "$KERNEL_BINARY")
+  if [[ "$FORCE" -eq 1 ]]; then
+    kernel_set_args+=(--force)
+  fi
+  run "${kernel_set_args[@]}"
+
+  if [[ "$SKIP_RESTART" -eq 0 ]]; then
+    log ""
+    log "Restarting container services..."
+    run container system stop
+    run container system start --disable-kernel-install
+  fi
+
+  print_kernel_state "Kernel configuration after change"
+  log ""
+  log "Done."
+}
+
+main "$@"


### PR DESCRIPTION
Adds Compose support for Apple `container` SMB/CIFS/NFS named volumes, plus a
helper script for swapping the guest kernel used during SMB/NFS testing.

Dependency features from pending PR:

- https://github.com/apple/container/pull/1428

Already merged PRs upstream:

- https://github.com/apple/containerization/pull/681
- https://github.com/kata-containers/kata-containers/pull/12374

## Changes

- Creates top-level Compose volumes through `ClientVolume.create`
- Preserves explicit Compose volume names via `volumes.<name>.name`
- Supports direct network volume drivers:
  - `driver: smb`
  - `driver: nfs`
- Normalizes Docker-style network volume definitions:
  - `type: cifs` or `type: smb` -> `driver: smb`
  - `type: nfs` -> `driver: nfs`
  - `device` -> `share`
  - comma-separated `o` options -> driver option key/value pairs
  - bare flags like `nolock` / `mfsymlinks` -> empty-value driver options
- Fails `compose up` before starting services if volume creation fails or an
existing volume has mismatched driver/options
- Adds focused tests for direct SMB/NFS drivers and Docker-style CIFS/NFS
normalization
- Adds `scripts/setup-container-kernel.sh` for guest-kernel swaps when testing
Apple `container` SMB/NFS support
- Documents how to build an SMB/CIFS-ready guest kernel from `apple/
containerization`

## Kernel Helper

Example:

```sh
./scripts/setup-container-kernel.sh --binary /path/to/vmlinux --force
```

The script validates the kernel binary, prints the configured kernel path before/
after, installs it with container system kernel set `--binary`, passes through
`--force`, restarts Apple container services by default, and supports `--dry-run` /
`--skip-restart`.

## SMB-Ready Kernel Build

SMB/CIFS mounts require a guest kernel with CIFS support enabled. apple/
containerization#681 enables CIFS in kernel/config-arm64, and Kata’s common
filesystem fragment also includes CIFS support.

```sh
git clone https://github.com/apple/containerization.git
cd containerization/kernel
grep -E 'CONFIG_(CIFS|NFS_FS)=' config-arm64
make
```

The resulting kernel is:

```text
containerization/kernel/vmlinux
```

Install it with:

```sh
./scripts/setup-container-kernel.sh --binary /path/to/containerization/kernel/vmlinux --force
```