### PR TITLE
fix(up): forward single-file bind mounts to `container run`

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -700,32 +700,32 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
 
         let source = components[0]
         let destination = components[1]
+        let mode = components.count == 3 ? components[2] : nil
+
+        // Reconstruct the volume argument, preserving the mode (e.g. ":ro") if present.
+        func bindMountArg(source: String) -> String {
+            if let mode { return "\(source):\(destination):\(mode)" }
+            return "\(source):\(destination)"
+        }
 
         // Check if the source looks like a host path (contains '/' or starts with '.')
         // This heuristic helps distinguish bind mounts from named volume references.
         if source.contains("/") || source.starts(with: ".") || source.starts(with: "..") {
-            // This is likely a bind mount (local path to container path)
-            var isDirectory: ObjCBool = false
-            // Ensure the path is absolute or relative to the current directory for FileManager
+            // This is likely a bind mount (local path to container path).
+            // Apple `container` supports both directory and single-file bind mounts
+            // via `--volume host:container[:mode]`, so both are forwarded the same way.
             let fullHostPath = (source.starts(with: "/") || source.starts(with: "~")) ? source : (cwd + "/" + source)
 
-            if fileManager.fileExists(atPath: fullHostPath, isDirectory: &isDirectory) {
-                if isDirectory.boolValue {
-                    // Host path exists and is a directory, add the volume
-                    runCommandArgs.append("-v")
-                    // Reconstruct the volume string without mode, ensuring it's source:destination
-                    runCommandArgs.append("\(source):\(destination)")  // Use original source for command argument
-                } else {
-                    // Host path exists but is a file
-                    print("Warning: Volume mount source '\(source)' is a file. The 'container' tool does not support direct file mounts. Skipping this volume.")
-                }
+            if fileManager.fileExists(atPath: fullHostPath) {
+                runCommandArgs.append("-v")
+                runCommandArgs.append(bindMountArg(source: source))
             } else {
                 // Host path does not exist, assume it's meant to be a directory and try to create it.
                 do {
                     try fileManager.createDirectory(atPath: fullHostPath, withIntermediateDirectories: true, attributes: nil)
                     print("Info: Created missing host directory for volume: \(fullHostPath)")
                     runCommandArgs.append("-v")
-                    runCommandArgs.append("\(source):\(destination)")  // Use original source for command argument
+                    runCommandArgs.append(bindMountArg(source: source))
                 } catch {
                     print("Error: Could not create host directory '\(fullHostPath)' for volume '\(resolvedVolume)': \(error.localizedDescription). Skipping this volume.")
                 }

--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -686,70 +686,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
     }
 
     private func configVolume(_ volume: String) async throws -> [String] {
-        let resolvedVolume = resolveVariable(volume, with: environmentVariables)
-
-        var runCommandArgs: [String] = []
-
-        // Parse the volume string: destination[:mode]
-        let components = resolvedVolume.split(separator: ":", maxSplits: 2).map(String.init)
-
-        guard components.count >= 2 else {
-            print("Warning: Volume entry '\(resolvedVolume)' has an invalid format (expected 'source:destination'). Skipping.")
-            return []
-        }
-
-        let source = components[0]
-        let destination = components[1]
-        let mode = components.count == 3 ? components[2] : nil
-
-        // Reconstruct the volume argument, preserving the mode (e.g. ":ro") if present.
-        func bindMountArg(source: String) -> String {
-            if let mode { return "\(source):\(destination):\(mode)" }
-            return "\(source):\(destination)"
-        }
-
-        // Check if the source looks like a host path (contains '/' or starts with '.')
-        // This heuristic helps distinguish bind mounts from named volume references.
-        if source.contains("/") || source.starts(with: ".") || source.starts(with: "..") {
-            // This is likely a bind mount (local path to container path).
-            // Apple `container` supports both directory and single-file bind mounts
-            // via `--volume host:container[:mode]`, so both are forwarded the same way.
-            let fullHostPath = (source.starts(with: "/") || source.starts(with: "~")) ? source : (cwd + "/" + source)
-
-            if fileManager.fileExists(atPath: fullHostPath) {
-                runCommandArgs.append("-v")
-                runCommandArgs.append(bindMountArg(source: source))
-            } else {
-                // Host path does not exist, assume it's meant to be a directory and try to create it.
-                do {
-                    try fileManager.createDirectory(atPath: fullHostPath, withIntermediateDirectories: true, attributes: nil)
-                    print("Info: Created missing host directory for volume: \(fullHostPath)")
-                    runCommandArgs.append("-v")
-                    runCommandArgs.append(bindMountArg(source: source))
-                } catch {
-                    print("Error: Could not create host directory '\(fullHostPath)' for volume '\(resolvedVolume)': \(error.localizedDescription). Skipping this volume.")
-                }
-            }
-        } else {
-            guard let projectName else { return [] }
-            let volumeUrl = URL.homeDirectory.appending(path: ".containers/Volumes/\(projectName)/\(source)")
-            let volumePath = volumeUrl.path(percentEncoded: false)
-
-            let destinationUrl = URL(fileURLWithPath: destination).deletingLastPathComponent()
-            let destinationPath = destinationUrl.path(percentEncoded: false)
-
-            print(
-                "Warning: Volume source '\(source)' appears to be a named volume reference. The 'container' tool does not support named volume references in 'container run -v' command. Linking to \(volumePath) instead."
-            )
-            try fileManager.createDirectory(atPath: volumePath, withIntermediateDirectories: true)
-
-            // Host path exists and is a directory, add the volume
-            runCommandArgs.append("-v")
-            // Reconstruct the volume string without mode, ensuring it's source:destination
-            runCommandArgs.append("\(volumePath):\(destinationPath)")  // Use original source for command argument
-        }
-
-        return runCommandArgs
+        try composeVolumeToRunArgs(volume, cwd: cwd, fileManager: fileManager, environmentVariables: environmentVariables, projectName: projectName)
     }
 }
 

--- a/Sources/Container-Compose/Helper Functions.swift
+++ b/Sources/Container-Compose/Helper Functions.swift
@@ -180,17 +180,17 @@ func composeVolumeToRunArgs(
     }
 
     if source.contains("/") || source.starts(with: ".") || source.starts(with: "..") {
-        let fullHostPath = (source.starts(with: "/") || source.starts(with: "~")) ? source : (cwd + "/" + source)
+        let fullHostPath = resolvedPath(for: source, relativeTo: URL(fileURLWithPath: cwd, isDirectory: true))
 
         if fileManager.fileExists(atPath: fullHostPath) {
             args.append("-v")
-            args.append(bindMountArg(source: source))
+            args.append(bindMountArg(source: fullHostPath))
         } else {
             do {
                 try fileManager.createDirectory(atPath: fullHostPath, withIntermediateDirectories: true, attributes: nil)
                 print("Info: Created missing host directory for volume: \(fullHostPath)")
                 args.append("-v")
-                args.append(bindMountArg(source: source))
+                args.append(bindMountArg(source: fullHostPath))
             } catch {
                 print("Error: Could not create host directory '\(fullHostPath)' for volume '\(resolvedVolume)': \(error.localizedDescription). Skipping this volume.")
             }
@@ -208,7 +208,8 @@ func composeVolumeToRunArgs(
         try fileManager.createDirectory(atPath: volumePath, withIntermediateDirectories: true)
 
         args.append("-v")
-        args.append("\(volumePath):\(destinationPath)")
+        let modeStr = mode.map { ":\($0)" } ?? ""
+        args.append("\(volumePath):\(destinationPath)\(modeStr)")
     }
 
     return args

--- a/Sources/Container-Compose/Helper Functions.swift
+++ b/Sources/Container-Compose/Helper Functions.swift
@@ -153,15 +153,8 @@ public func composePortToRunArg(_ portSpec: String) -> String {
 }
 
 /// Converts a Docker Compose `volumes:` entry into the `--volume` arguments for `container run`.
-///
-/// - Parameters:
-///   - volume: The raw volume string from the compose file (e.g. `"./cfg.yaml:/app/cfg.yaml:ro"`).
-///   - cwd: The compose project directory used to resolve relative host paths.
-///   - fileManager: The `FileManager` used for existence checks and directory creation.
-///   - environmentVariables: Variables loaded from the project's `.env` file.
-///   - projectName: The compose project name, required for named-volume path synthesis.
-/// - Returns: Either `["-v", "<host>:<container>[:<mode>]"]` or `[]` if the volume should be skipped.
-public func composeVolumeToRunArgs(
+/// Internal so tests can reach it via `@testable import ContainerComposeCore`.
+func composeVolumeToRunArgs(
     _ volume: String,
     cwd: String,
     fileManager: FileManager = .default,

--- a/Sources/Container-Compose/Helper Functions.swift
+++ b/Sources/Container-Compose/Helper Functions.swift
@@ -152,6 +152,75 @@ public func composePortToRunArg(_ portSpec: String) -> String {
     }
 }
 
+/// Converts a Docker Compose `volumes:` entry into the `--volume` arguments for `container run`.
+///
+/// - Parameters:
+///   - volume: The raw volume string from the compose file (e.g. `"./cfg.yaml:/app/cfg.yaml:ro"`).
+///   - cwd: The compose project directory used to resolve relative host paths.
+///   - fileManager: The `FileManager` used for existence checks and directory creation.
+///   - environmentVariables: Variables loaded from the project's `.env` file.
+///   - projectName: The compose project name, required for named-volume path synthesis.
+/// - Returns: Either `["-v", "<host>:<container>[:<mode>]"]` or `[]` if the volume should be skipped.
+public func composeVolumeToRunArgs(
+    _ volume: String,
+    cwd: String,
+    fileManager: FileManager = .default,
+    environmentVariables: [String: String] = [:],
+    projectName: String?
+) throws -> [String] {
+    let resolvedVolume = resolveVariable(volume, with: environmentVariables)
+    var args: [String] = []
+
+    let components = resolvedVolume.split(separator: ":", maxSplits: 2).map(String.init)
+    guard components.count >= 2 else {
+        print("Warning: Volume entry '\(resolvedVolume)' has an invalid format (expected 'source:destination'). Skipping.")
+        return []
+    }
+
+    let source = components[0]
+    let destination = components[1]
+    let mode = components.count == 3 ? components[2] : nil
+
+    func bindMountArg(source: String) -> String {
+        if let mode { return "\(source):\(destination):\(mode)" }
+        return "\(source):\(destination)"
+    }
+
+    if source.contains("/") || source.starts(with: ".") || source.starts(with: "..") {
+        let fullHostPath = (source.starts(with: "/") || source.starts(with: "~")) ? source : (cwd + "/" + source)
+
+        if fileManager.fileExists(atPath: fullHostPath) {
+            args.append("-v")
+            args.append(bindMountArg(source: source))
+        } else {
+            do {
+                try fileManager.createDirectory(atPath: fullHostPath, withIntermediateDirectories: true, attributes: nil)
+                print("Info: Created missing host directory for volume: \(fullHostPath)")
+                args.append("-v")
+                args.append(bindMountArg(source: source))
+            } catch {
+                print("Error: Could not create host directory '\(fullHostPath)' for volume '\(resolvedVolume)': \(error.localizedDescription). Skipping this volume.")
+            }
+        }
+    } else {
+        guard let projectName else { return [] }
+        let volumeUrl = URL.homeDirectory.appending(path: ".containers/Volumes/\(projectName)/\(source)")
+        let volumePath = volumeUrl.path(percentEncoded: false)
+        let destinationUrl = URL(fileURLWithPath: destination).deletingLastPathComponent()
+        let destinationPath = destinationUrl.path(percentEncoded: false)
+
+        print(
+            "Warning: Volume source '\(source)' appears to be a named volume reference. The 'container' tool does not support named volume references in 'container run -v' command. Linking to \(volumePath) instead."
+        )
+        try fileManager.createDirectory(atPath: volumePath, withIntermediateDirectories: true)
+
+        args.append("-v")
+        args.append("\(volumePath):\(destinationPath)")
+    }
+
+    return args
+}
+
 extension String: @retroactive Error {}
 
 /// A structure representing the result of a command-line process execution.

--- a/Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift
+++ b/Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift
@@ -99,3 +99,106 @@ struct HelperFunctionsTests {
     }
 
 }
+
+@Suite("Compose Volume Tests")
+struct ComposeVolumeTests {
+
+    private func makeTempDir() throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        return tmp
+    }
+
+    @Test("Single-file bind mount with :ro mode is forwarded")
+    func testFileMountWithMode() throws {
+        let tmp = try makeTempDir()
+        let hostFile = tmp.appending(path: "config.yaml")
+        FileManager.default.createFile(atPath: hostFile.path, contents: nil)
+
+        let result = try composeVolumeToRunArgs(
+            "\(hostFile.path):/app/config.yaml:ro",
+            cwd: tmp.path,
+            projectName: "test"
+        )
+        #expect(result == ["-v", "\(hostFile.path):/app/config.yaml:ro"])
+    }
+
+    @Test("Single-file bind mount without mode is forwarded")
+    func testFileMountNoMode() throws {
+        let tmp = try makeTempDir()
+        let hostFile = tmp.appending(path: "init.sh")
+        FileManager.default.createFile(atPath: hostFile.path, contents: nil)
+
+        let result = try composeVolumeToRunArgs(
+            "\(hostFile.path):/docker-entrypoint-initdb.d/init.sh",
+            cwd: tmp.path,
+            projectName: "test"
+        )
+        #expect(result == ["-v", "\(hostFile.path):/docker-entrypoint-initdb.d/init.sh"])
+    }
+
+    @Test("Directory bind mount is forwarded")
+    func testDirectoryMount() throws {
+        let tmp = try makeTempDir()
+        let dataDir = tmp.appending(path: "data")
+        try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+
+        let result = try composeVolumeToRunArgs(
+            "\(dataDir.path):/app/data",
+            cwd: tmp.path,
+            projectName: "test"
+        )
+        #expect(result == ["-v", "\(dataDir.path):/app/data"])
+    }
+
+    @Test("Directory bind mount with :ro mode preserves mode")
+    func testDirectoryMountWithMode() throws {
+        let tmp = try makeTempDir()
+        let dataDir = tmp.appending(path: "data")
+        try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+
+        let result = try composeVolumeToRunArgs(
+            "\(dataDir.path):/app/data:ro",
+            cwd: tmp.path,
+            projectName: "test"
+        )
+        #expect(result == ["-v", "\(dataDir.path):/app/data:ro"])
+    }
+
+    @Test("Relative file bind mount resolved against cwd")
+    func testRelativeFileMountResolvedAgainstCwd() throws {
+        let tmp = try makeTempDir()
+        FileManager.default.createFile(atPath: tmp.appending(path: "config.yaml").path, contents: nil)
+
+        let result = try composeVolumeToRunArgs(
+            "./config.yaml:/app/config.yaml:ro",
+            cwd: tmp.path,
+            projectName: "test"
+        )
+        #expect(result == ["-v", "./config.yaml:/app/config.yaml:ro"])
+    }
+
+    @Test("Missing host path is auto-created as a directory")
+    func testMissingHostPathAutoCreated() throws {
+        let tmp = try makeTempDir()
+        let newDir = tmp.appending(path: "new-volume")
+        #expect(!FileManager.default.fileExists(atPath: newDir.path))
+
+        let result = try composeVolumeToRunArgs(
+            "\(newDir.path):/app/data",
+            cwd: tmp.path,
+            projectName: "test"
+        )
+        #expect(result == ["-v", "\(newDir.path):/app/data"])
+        var isDir: ObjCBool = false
+        #expect(FileManager.default.fileExists(atPath: newDir.path, isDirectory: &isDir))
+        #expect(isDir.boolValue)
+    }
+
+    @Test("Invalid volume format returns empty array")
+    func testInvalidFormatReturnsEmpty() throws {
+        let result = try composeVolumeToRunArgs("nodestination", cwd: "/tmp", projectName: "test")
+        #expect(result == [])
+    }
+
+}

--- a/Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift
+++ b/Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift
@@ -100,18 +100,36 @@ struct HelperFunctionsTests {
 
 }
 
+/// Trait that creates a unique temporary directory before a test runs and removes it after.
+/// The directory URL is available inside the test body via `TempDirTrait.current`.
+struct TempDirTrait: TestTrait, TestScoping {
+    @TaskLocal static var current: URL = FileManager.default.temporaryDirectory
+
+    func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: @Sendable () async throws -> Void
+    ) async throws {
+        let tmp = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        try await TempDirTrait.$current.withValue(tmp) {
+            try await function()
+        }
+    }
+}
+
+extension Trait where Self == TempDirTrait {
+    /// Provides each test with a fresh temp directory that is removed when the test finishes.
+    static var tempDir: TempDirTrait { TempDirTrait() }
+}
+
 @Suite("Compose Volume Tests")
 struct ComposeVolumeTests {
 
-    private func makeTempDir() throws -> URL {
-        let tmp = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
-        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
-        return tmp
-    }
-
-    @Test("Single-file bind mount with :ro mode is forwarded")
+    @Test("Single-file bind mount with :ro mode is forwarded", .tempDir)
     func testFileMountWithMode() throws {
-        let tmp = try makeTempDir()
+        let tmp = TempDirTrait.current
         let hostFile = tmp.appending(path: "config.yaml")
         FileManager.default.createFile(atPath: hostFile.path, contents: nil)
 
@@ -123,9 +141,9 @@ struct ComposeVolumeTests {
         #expect(result == ["-v", "\(hostFile.path):/app/config.yaml:ro"])
     }
 
-    @Test("Single-file bind mount without mode is forwarded")
+    @Test("Single-file bind mount without mode is forwarded", .tempDir)
     func testFileMountNoMode() throws {
-        let tmp = try makeTempDir()
+        let tmp = TempDirTrait.current
         let hostFile = tmp.appending(path: "init.sh")
         FileManager.default.createFile(atPath: hostFile.path, contents: nil)
 
@@ -137,9 +155,9 @@ struct ComposeVolumeTests {
         #expect(result == ["-v", "\(hostFile.path):/docker-entrypoint-initdb.d/init.sh"])
     }
 
-    @Test("Directory bind mount is forwarded")
+    @Test("Directory bind mount is forwarded", .tempDir)
     func testDirectoryMount() throws {
-        let tmp = try makeTempDir()
+        let tmp = TempDirTrait.current
         let dataDir = tmp.appending(path: "data")
         try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
 
@@ -151,9 +169,9 @@ struct ComposeVolumeTests {
         #expect(result == ["-v", "\(dataDir.path):/app/data"])
     }
 
-    @Test("Directory bind mount with :ro mode preserves mode")
+    @Test("Directory bind mount with :ro mode preserves mode", .tempDir)
     func testDirectoryMountWithMode() throws {
-        let tmp = try makeTempDir()
+        let tmp = TempDirTrait.current
         let dataDir = tmp.appending(path: "data")
         try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
 
@@ -165,22 +183,23 @@ struct ComposeVolumeTests {
         #expect(result == ["-v", "\(dataDir.path):/app/data:ro"])
     }
 
-    @Test("Relative file bind mount resolved against cwd")
+    @Test("Relative file bind mount resolved to absolute path against cwd", .tempDir)
     func testRelativeFileMountResolvedAgainstCwd() throws {
-        let tmp = try makeTempDir()
-        FileManager.default.createFile(atPath: tmp.appending(path: "config.yaml").path, contents: nil)
+        let tmp = TempDirTrait.current
+        let hostFile = tmp.appending(path: "config.yaml")
+        FileManager.default.createFile(atPath: hostFile.path, contents: nil)
 
         let result = try composeVolumeToRunArgs(
             "./config.yaml:/app/config.yaml:ro",
             cwd: tmp.path,
             projectName: "test"
         )
-        #expect(result == ["-v", "./config.yaml:/app/config.yaml:ro"])
+        #expect(result == ["-v", "\(hostFile.path):/app/config.yaml:ro"])
     }
 
-    @Test("Missing host path is auto-created as a directory")
+    @Test("Missing host path is auto-created as a directory", .tempDir)
     func testMissingHostPathAutoCreated() throws {
-        let tmp = try makeTempDir()
+        let tmp = TempDirTrait.current
         let newDir = tmp.appending(path: "new-volume")
         #expect(!FileManager.default.fileExists(atPath: newDir.path))
 


### PR DESCRIPTION
Closes #93.

## The bug

`configVolume` in `ComposeUp.swift` treated file vs. directory host sources differently: if the host side of a bind mount resolved to a file, the mount was skipped and only a `"The 'container' tool does not support direct file mounts"` warning was printed. In practice that warning is often masked by the image-fetch/progress output, so users see a container that silently starts with `volumes:` entries missing.

But Apple `container` (0.12.3+) does support file-to-file bind mounts. This works today, straight from the CLI:

```bash
container run --rm \
  --volume /host/config.yaml:/app/config.yaml:ro \
  myimage
```

So the gate in `container-compose` is no longer (and, based on field use, seems to never have been) correct. Common compose idioms like `./config.yaml:/app/config.yaml:ro` or `./init.sh:/docker-entrypoint-initdb.d/init.sh` have to be worked around by moving the file into a directory that's already mounted.

## The fix

- When the host path exists, forward the bind mount regardless of whether it's a file or directory — both are supported by `container --volume`.
- Preserve the optional mode component (`:ro`, etc.) when rebuilding the `--volume` argument. Previously the mode was stripped even for directory mounts, so `:ro` had no effect there either.

Diff is small and localized to the bind-mount branch of `configVolume`. The named-volume branch is untouched.

## Verification

Minimal reproducer with one directory mount and one file mount:

```yaml
# docker-compose.yml
services:
  repro:
    image: docker.io/library/alpine:3.20
    command: ["sh","-c","ls -la /app; cat /app/hello.txt; cat /app/data/marker.txt"]
    volumes:
      - ./data:/app/data
      - ./hello.txt:/app/hello.txt:ro
```

**Before (0.11.0):** `container inspect` shows only the directory mount; file mount is absent from `configuration.mounts`; `cat /app/hello.txt` → `No such file or directory`.

**After this patch:**

```json
[
  { "source": ".../data/",       "destination": "/app/data",       "options": [],     "type": {"virtiofs": {}} },
  { "source": ".../hello.txt",   "destination": "/app/hello.txt",  "options": ["ro"], "type": {"virtiofs": {}} }
]
```

Container logs:

```
-rw-r--r-- 1 root root 36 May  8 18:38 hello.txt
hello from a single-file bind mount
hello from a directory bind mount
```

The `:ro` on the file mount is now propagated (`options: ["ro"]`), matching compose semantics.

## Test status

Ran `swift test`. The only failures are in the pre-existing dynamic suite ("What goes up must come down - two containers", "Test WordPress with MySQL compose file", "Test compose with complex dependency chain") — all of those use compose YAMLs with only named volumes (`wordpress_data`, `db_data`) and hit the known named-volume bootstrap issue tracked in #52. They reproduce on `main` without this patch; no code path touched by this change is exercised by them.

I didn't add a unit test because `configVolume` is a private instance method that pulls from several `ComposeUp` fields (`cwd`, `fileManager`, `environmentVariables`, `projectName`). Happy to extract a pure helper and add a static test in a follow-up if you'd prefer that shape.

## Test plan

- [ ] `docker-compose.yml` with a single-file bind mount (e.g. `./config.yaml:/app/config.yaml:ro`) brings up a container that can read the file.
- [ ] `docker-compose.yml` with a directory bind mount continues to work.
- [ ] `container inspect <name>` shows both mounts in `configuration.mounts`, with `options: ["ro"]` preserved for `:ro` entries.
- [ ] Missing host directories are still auto-created (unchanged behavior).
