### PR TITLE
fix(run): resolve service IP from container address, not network gateway

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -254,7 +254,10 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
 
         let client = ContainerClient()
         let container = try await client.get(id: containerName)
-        let ip = container.networks.compactMap { $0.ipv4Gateway.description }.first
+        // Use the container's own address, not the network gateway — every
+        // container on a network shares the same gateway, so substituting the
+        // gateway broke service-name -> IP environment resolution.
+        let ip = container.networks.compactMap { $0.ipv4Address.address.description }.first
 
         return ip
     }


### PR DESCRIPTION
Environment values matching a service name are substituted with that service's IP, but getIPForRunningService returned the attachment's ipv4Gateway — the same gateway for every container on the network — so e.g. DATABASE_HOST=db pointed at the gateway instead of the db container and dependents waited for the database forever. Use the attachment's own ipv4Address instead.