### PR TITLE
fix(run): do not pass unsupported --hostname to container run

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -533,11 +533,12 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             print("Note: Service '\(serviceName)' is not explicitly connected to any networks. It will likely use the default bridge network.")
         }
 
-        // Add hostname
+        // The 'hostname' field is not supported by `container run` (no --hostname
+        // flag); passing it would make the whole run command fail to parse.
         if let hostname = service.hostname {
-            let resolvedHostname = resolveVariable(hostname, with: environmentVariables)
-            runCommandArgs.append("--hostname")
-            runCommandArgs.append(resolvedHostname)
+            print(
+                "Note: Service '\(serviceName)' sets 'hostname: \(hostname)', but the 'container' tool does not support setting a hostname. The field is ignored."
+            )
         }
 
         // Add working directory


### PR DESCRIPTION
The container CLI has no --hostname flag, so any service declaring 'hostname:' made the whole run command fail with "Unknown option '--hostname'". The field is now ignored with an explanatory note, matching how the unsupported restart policy is handled.