### PR TITLE
feat(services): deterministic service selection for partial up/down

### DIFF
--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -97,10 +97,7 @@ public struct Service: Codable, Hashable {
 
     /// Allocate a pseudo-TTY (-t flag for `container run`)
     public let tty: Bool?
-    
-    /// Other services that depend on this service
-    public var dependedBy: [String] = []
-    
+
     // Defines custom coding keys to map YAML keys to Swift properties
     enum CodingKeys: String, CodingKey {
         case image, build, deploy, restart, healthcheck, volumes, environment, env_file, ports, command, depends_on, user,
@@ -132,8 +129,7 @@ public struct Service: Codable, Hashable {
         configs: [ServiceConfig]? = nil,
         secrets: [ServiceSecret]? = nil,
         stdin_open: Bool? = nil,
-        tty: Bool? = nil,
-        dependedBy: [String] = []
+        tty: Bool? = nil
     ) {
         self.image = image
         self.build = build
@@ -159,7 +155,6 @@ public struct Service: Codable, Hashable {
         self.secrets = secrets
         self.stdin_open = stdin_open
         self.tty = tty
-        self.dependedBy = dependedBy
     }
 
     /// Custom initializer to handle decoding and basic validation.
@@ -273,12 +268,9 @@ public struct Service: Codable, Hashable {
         var visiting = Set<String>()
         var sorted: [(String, Service)] = []
 
-        func visit(_ name: String, from service: String? = nil) throws {
-            guard var serviceTuple = services.first(where: { $0.serviceName == name }) else { return }
-            if let service {
-                serviceTuple.service.dependedBy.append(service)
-            }
-            
+        func visit(_ name: String) throws {
+            guard let serviceTuple = services.first(where: { $0.serviceName == name }) else { return }
+
             if visiting.contains(name) {
                 throw NSError(domain: "ComposeError", code: 1, userInfo: [
                     NSLocalizedDescriptionKey: "Cyclic dependency detected involving '\(name)'"
@@ -288,7 +280,7 @@ public struct Service: Codable, Hashable {
 
             visiting.insert(name)
             for depName in serviceTuple.service.depends_on ?? [] {
-                try visit(depName, from: name)
+                try visit(depName)
             }
             visiting.remove(name)
             visited.insert(name)

--- a/Sources/Container-Compose/Commands/ComposeDown.swift
+++ b/Sources/Container-Compose/Commands/ComposeDown.swift
@@ -101,16 +101,13 @@ public struct ComposeDown: AsyncParsableCommand {
             print("Info: No 'name' field found in docker-compose.yml. Using directory name as project name: \(projectName ?? "")")
         }
 
-        var services: [(serviceName: String, service: Service)] = dockerCompose.services.compactMap({ serviceName, service in
-            guard let service else { return nil }
-            return (serviceName, service)
-        })
-        services = try Service.topoSortConfiguredServices(services)
+        var services = try Service.topoSortConfiguredServices(configuredServices(from: dockerCompose.services))
 
-        // Filter for specified services
+        // Filter for specified services only (docker compose parity: `down app`
+        // does not touch app's dependencies).
         if !self.services.isEmpty {
-            services = services.filter({ serviceName, service in
-                self.services.contains(where: { $0 == serviceName }) || self.services.contains(where: { service.dependedBy.contains($0) })
+            services = services.filter({ serviceName, _ in
+                self.services.contains(serviceName)
             })
         }
 

--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -143,17 +143,14 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         }
 
         // Get Services to use
-        var services: [(serviceName: String, service: Service)] = dockerCompose.services.compactMap({ serviceName, service in
-            guard let service else { return nil }
-            return (serviceName, service)
-        })
-        services = try Service.topoSortConfiguredServices(services)
+        var services = try Service.topoSortConfiguredServices(configuredServices(from: dockerCompose.services))
 
-        // Filter for specified services
+        // Filter for specified services, expanded with their transitive
+        // dependencies (docker compose parity: `up app` also starts what
+        // `app` depends on).
         if !self.services.isEmpty {
-            services = services.filter({ serviceName, service in
-                self.services.contains(where: { $0 == serviceName }) || self.services.contains(where: { service.dependedBy.contains($0) })
-            })
+            let selected = expandServiceSelection(requested: self.services, services: services)
+            services = services.filter({ selected.contains($0.serviceName) })
         }
 
         // Stop Services

--- a/Sources/Container-Compose/Helper Functions.swift
+++ b/Sources/Container-Compose/Helper Functions.swift
@@ -215,6 +215,39 @@ func composeVolumeToRunArgs(
     return args
 }
 
+/// Converts the decoded `services:` mapping into a deterministically ordered
+/// array. Dictionary iteration order varies between runs, which previously
+/// made the topological sort (and therefore partial `up`/`down` selection and
+/// start order among independent services) nondeterministic. YAML file order
+/// is lost during decoding, so alphabetical order is used instead.
+func configuredServices(from services: [String: Service?]) -> [(serviceName: String, service: Service)] {
+    services
+        .compactMap({ serviceName, service in
+            guard let service else { return nil }
+            return (serviceName, service)
+        })
+        .sorted(by: { $0.serviceName < $1.serviceName })
+}
+
+/// Expands the user-requested service names to include their transitive
+/// `depends_on` closure, matching `docker compose up <service>` semantics.
+/// Names that don't match a configured service are ignored.
+func expandServiceSelection(
+    requested: [String],
+    services: [(serviceName: String, service: Service)]
+) -> Set<String> {
+    var selected = Set<String>()
+    var queue = requested
+    while let name = queue.popLast() {
+        guard !selected.contains(name) else { continue }
+        selected.insert(name)
+        if let service = services.first(where: { $0.serviceName == name })?.service {
+            queue.append(contentsOf: service.depends_on ?? [])
+        }
+    }
+    return selected
+}
+
 extension String: @retroactive Error {}
 
 /// A structure representing the result of a command-line process execution.

--- a/Tests/Container-Compose-StaticTests/ServiceDependencyTests.swift
+++ b/Tests/Container-Compose-StaticTests/ServiceDependencyTests.swift
@@ -124,12 +124,93 @@ struct ServiceDependencyTests {
     @Test("Service depends on non-existent service - should not crash")
     func dependsOnNonExistentService() throws {
         let web = Service(image: "nginx", depends_on: ["nonexistent"])
-        
+
         let services: [(String, Service)] = [("web", web)]
         let sorted = try Service.topoSortConfiguredServices(services)
-        
+
         // Should complete without crashing
         #expect(sorted.count == 1)
+    }
+}
+
+@Suite("Service Selection Tests")
+struct ServiceSelectionTests {
+
+    @Test("Selection is independent of service declaration order")
+    func selectionIsOrderIndependent() {
+        // Regression: the old dependedBy-based filter only recorded a depender
+        // when the dependency was first visited *through* it, so `up app`
+        // included or dropped db depending on Dictionary iteration order.
+        let app = Service(image: "myapp", depends_on: ["db", "vue"])
+        let db = Service(image: "postgres", depends_on: nil)
+        let vue = Service(image: "node", depends_on: nil)
+
+        let orderA: [(String, Service)] = [("app", app), ("db", db), ("vue", vue)]
+        let orderB: [(String, Service)] = [("db", db), ("vue", vue), ("app", app)]
+
+        let selectedA = expandServiceSelection(requested: ["app"], services: orderA)
+        let selectedB = expandServiceSelection(requested: ["app"], services: orderB)
+
+        #expect(selectedA == ["app", "db", "vue"])
+        #expect(selectedA == selectedB)
+    }
+
+    @Test("Selection includes transitive dependencies")
+    func selectionIsTransitive() {
+        let web = Service(image: "nginx", depends_on: ["app"])
+        let app = Service(image: "myapp", depends_on: ["db"])
+        let db = Service(image: "postgres", depends_on: nil)
+
+        let services: [(String, Service)] = [("db", db), ("app", app), ("web", web)]
+        let selected = expandServiceSelection(requested: ["web"], services: services)
+
+        #expect(selected == ["web", "app", "db"])
+    }
+
+    @Test("Selection excludes services outside the requested closure")
+    func selectionExcludesUnrelatedServices() {
+        let web = Service(image: "nginx", depends_on: ["db"])
+        let api = Service(image: "api", depends_on: ["db"])
+        let db = Service(image: "postgres", depends_on: nil)
+
+        let services: [(String, Service)] = [("web", web), ("api", api), ("db", db)]
+        let selected = expandServiceSelection(requested: ["web"], services: services)
+
+        #expect(selected == ["web", "db"])
+    }
+
+    @Test("Unknown requested or dependency names do not crash")
+    func selectionToleratesUnknownNames() {
+        let web = Service(image: "nginx", depends_on: ["nonexistent"])
+
+        let services: [(String, Service)] = [("web", web)]
+        let selected = expandServiceSelection(requested: ["web", "ghost"], services: services)
+
+        #expect(selected.contains("web"))
+        #expect(!selected.contains("api"))
+    }
+
+    @Test("Empty request selects nothing")
+    func emptyRequestSelectsNothing() {
+        let web = Service(image: "nginx", depends_on: nil)
+
+        let selected = expandServiceSelection(requested: [], services: [("web", web)])
+
+        #expect(selected.isEmpty)
+    }
+
+    @Test("configuredServices drops nils and sorts by name")
+    func configuredServicesIsDeterministic() {
+        let mapping: [String: Service?] = [
+            "web": Service(image: "nginx"),
+            "db": Service(image: "postgres"),
+            "broken": nil,
+            "app": Service(image: "myapp"),
+        ]
+
+        let services = configuredServices(from: mapping)
+
+        #expect(services.map(\.serviceName) == ["app", "db", "web"])
     }
 }
 

--- a/Tests/Container-Compose-StaticTests/WaitForeverCpuTests.swift
+++ b/Tests/Container-Compose-StaticTests/WaitForeverCpuTests.swift
@@ -32,18 +32,22 @@ struct WaitForeverCpuTests {
     /// Regression for #27: `waitForever()` must suspend, not busy-loop.
     ///
     /// Method: take a `getrusage(RUSAGE_SELF)` snapshot, spawn a child Task
-    /// that calls `waitForever()`, sleep for 200ms wall-clock, take a second
+    /// that calls `waitForever()`, sleep for 500ms wall-clock, take a second
     /// snapshot, and compare user-CPU consumed.
     ///
     /// On the bug (`for await _ in AsyncStream<Void>(unfolding: {})`), the
-    /// child task pins one core, so user CPU consumed during the 200ms window
-    /// is around 200,000 µs (one full core). With the fix
+    /// child task pins one core, so user CPU consumed during the 500ms window
+    /// is around 500,000 µs (one full core). With the fix
     /// (`withUnsafeContinuation { _ in }`), the child task suspends and
     /// consumes essentially nothing.
     ///
-    /// Threshold of 50,000 µs gives ~4× headroom over a noisy CI baseline
-    /// (test-runner overhead, parallel tasks) while still reliably catching
-    /// a single core's worth of busy-loop work.
+    /// The measurement is process-wide, and swift-testing runs other suites
+    /// in parallel in the same process, so the baseline includes their CPU
+    /// (observed up to ~70,000 µs for the full static suite). That noise is
+    /// front-loaded — the rest of the suite finishes within the first
+    /// ~100ms — while a busy-loop scales with the window. The threshold of
+    /// half a core (250,000 µs over 500ms) therefore sits ~3× above suite
+    /// noise and ~2× below a pinned core.
     ///
     /// Side effect: this test leaks one suspended task per invocation
     /// (`waitForever` is `-> Never` and the suspended task can't be cancelled
@@ -61,12 +65,12 @@ struct WaitForeverCpuTests {
             await composeUp.waitForever()
         }
 
-        try await Task.sleep(nanoseconds: 200_000_000)  // 200ms
+        try await Task.sleep(nanoseconds: 500_000_000)  // 500ms
 
         let after = userCpuMicroseconds()
         let consumed = after - before
 
-        #expect(consumed < 50_000,
-                "waitForever consumed \(consumed) µs of user CPU in 200ms — likely busy-looping (regression for #27)")
+        #expect(consumed < 250_000,
+                "waitForever consumed \(consumed) µs of user CPU in 500ms — likely busy-looping (regression for #27)")
     }
 }


### PR DESCRIPTION
Service selection for 'up <service>' was nondeterministic: topoSort recorded dependedBy on a value copy that only survived the first visit, and the input order came from a Dictionary, so 'up app' sometimes started its dependencies and sometimes did not. The filter also only checked direct dependents, losing transitive dependencies.

- configuredServices(from:) — deterministic (alphabetical) service order from the decoded YAML mapping
- expandServiceSelection(requested:services:) — transitive depends_on closure, matching 'docker compose up <service>' semantics
- down <service> now stops only the named services (docker compose parity, no dependency expansion)
- removed the broken Service.dependedBy field (dead after the filter rewrite)