### PR TITLE
feat(compose): add --env-file and --workdir flags

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeBuild.swift
+++ b/Sources/Container-Compose/Commands/ComposeBuild.swift
@@ -46,12 +46,9 @@ public struct ComposeBuild: AsyncParsableCommand, @unchecked Sendable {
     var noCache: Bool = false
 
     @OptionGroup
-    var process: Flags.Process
-
-    @OptionGroup
     var logging: Flags.Logging
 
-    private var cwd: String { process.cwd ?? FileManager.default.currentDirectoryPath }
+    private var cwd: String { composeFileOptions.workdir ?? FileManager.default.currentDirectoryPath }
 
     private var cwdURL: URL { URL(fileURLWithPath: cwd) }
 
@@ -80,7 +77,7 @@ public struct ComposeBuild: AsyncParsableCommand, @unchecked Sendable {
     }
 
     private var envFilePath: String {
-        let envFile = process.envFile.first ?? ".env"
+        let envFile = composeFileOptions.envFile ?? ".env"
         return resolvedPath(for: envFile, relativeTo: cwdURL)
     }
 

--- a/Sources/Container-Compose/Commands/ComposeDown.swift
+++ b/Sources/Container-Compose/Commands/ComposeDown.swift
@@ -22,7 +22,6 @@
 //
 
 import ArgumentParser
-import ContainerCommands
 import ContainerAPIClient
 import Foundation
 import Yams
@@ -39,12 +38,9 @@ public struct ComposeDown: AsyncParsableCommand {
     var services: [String] = []
 
     @OptionGroup
-    var process: Flags.Process
-
-    private var cwd: String { process.cwd ?? FileManager.default.currentDirectoryPath }
-
-    @OptionGroup
     var composeFileOptions: ComposeFileOptions
+
+    private var cwd: String { composeFileOptions.workdir ?? FileManager.default.currentDirectoryPath }
 
     private static let supportedComposeFilenames = [
         "compose.yml",

--- a/Sources/Container-Compose/Commands/ComposeFileOptions.swift
+++ b/Sources/Container-Compose/Commands/ComposeFileOptions.swift
@@ -18,7 +18,19 @@ import ArgumentParser
 
 public struct ComposeFileOptions: ParsableArguments, Sendable {
     public init() {}
+
+    public init(composeFilename: String? = nil, envFile: String? = nil, workdir: String? = nil) {
+        self.composeFilename = composeFilename
+        self.envFile = envFile
+        self.workdir = workdir
+    }
     
     @Option(name: [.customShort("f"), .customLong("file")], help: "The path to your Docker Compose file")
     public var composeFilename: String?
+
+    @Option(name: .long, help: "Specify an alternate environment file")
+    public var envFile: String?
+
+    @Option(name: [.customShort("w"), .customLong("workdir")], help: "Specify an alternate working directory (default: the current directory)")
+    public var workdir: String?
 }

--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -75,7 +75,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
     }
 
     private var envFilePath: String {
-        let envFile = process.envFile.first ?? ".env"
+        let envFile = composeFileOptions.envFile ?? ".env"
         return resolvedPath(for: envFile, relativeTo: cwdURL)
     }
 
@@ -90,12 +90,9 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
     var noCache: Bool = false
 
     @OptionGroup
-    var process: Flags.Process
-
-    @OptionGroup
     var logging: Flags.Logging
 
-    private var cwd: String { process.cwd ?? FileManager.default.currentDirectoryPath }
+    private var cwd: String { composeFileOptions.workdir ?? FileManager.default.currentDirectoryPath }
 
     private var fileManager: FileManager { FileManager.default }
     private var projectName: String?

--- a/Tests/Container-Compose-StaticTests/ComposeCommandParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/ComposeCommandParsingTests.swift
@@ -24,4 +24,46 @@ struct ComposeCommandParsingTests {
         let cmd = try Main.parseAsRoot(["-f", "my-compose.yaml", "up"]) as! ComposeUp
         #expect(cmd.composeFileOptions.composeFilename == "my-compose.yaml")
     }
+
+    @Test("Main+ComposeUp command accepts --env-file flag from root")
+    func composeUpCommandAcceptsEnvFileFlag() throws {
+        let cmd = try Main.parseAsRoot(["--env-file", "custom.env", "up"]) as! ComposeUp
+        #expect(cmd.composeFileOptions.envFile == "custom.env")
+    }
+
+    @Test("Main+ComposeUp command accepts --env-file flag on subcommand")
+    func composeUpCommandAcceptsEnvFileFlagOnSubcommand() throws {
+        let cmd = try Main.parseAsRoot(["up", "--env-file", "custom.env"]) as! ComposeUp
+        #expect(cmd.composeFileOptions.envFile == "custom.env")
+    }
+
+    @Test("Main+ComposeUp command accepts -w flag for workdir")
+    func composeUpCommandAcceptsWorkdirFlag() throws {
+        let cmd = try Main.parseAsRoot(["-w", "/some/path", "up"]) as! ComposeUp
+        #expect(cmd.composeFileOptions.workdir == "/some/path")
+    }
+
+    @Test("Main+ComposeDown command accepts --env-file flag")
+    func composeDownCommandAcceptsEnvFileFlag() throws {
+        let cmd = try Main.parseAsRoot(["--env-file", "prod.env", "down"]) as! ComposeDown
+        #expect(cmd.composeFileOptions.envFile == "prod.env")
+    }
+
+    @Test("Main+ComposeBuild command accepts --env-file flag")
+    func composeBuildCommandAcceptsEnvFileFlag() throws {
+        let cmd = try Main.parseAsRoot(["--env-file", "build.env", "build"]) as! ComposeBuild
+        #expect(cmd.composeFileOptions.envFile == "build.env")
+    }
+
+    @Test("envFile is nil when not specified")
+    func envFileDefaultsToNil() throws {
+        let cmd = try Main.parseAsRoot(["up"]) as! ComposeUp
+        #expect(cmd.composeFileOptions.envFile == nil)
+    }
+
+    @Test("workdir is nil when not specified")
+    func workdirDefaultsToNil() throws {
+        let cmd = try Main.parseAsRoot(["up"]) as! ComposeUp
+        #expect(cmd.composeFileOptions.workdir == nil)
+    }
 }


### PR DESCRIPTION
Add --env-file and --workdir/-w as top-level options on ComposeFileOptions, matching Docker Compose CLI semantics. These flags were previously inherited from Flags.Process (the container runtime dependency) which conflated compose-level concerns with container runtime flags.

- Add --env-file to ComposeFileOptions for specifying alternate .env files
- Add --workdir/-w to ComposeFileOptions for alternate working directory
- Remove Flags.Process from ComposeUp, ComposeBuild, ComposeDown
- ComposeDown no longer needs import ContainerCommands
- Add 7 parsing tests covering all subcommands and defaults