### PR TITLE
Improve Apple container compose compatibility

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "88a8c9d7a638866eedf9a6130a6e13bdb1a21e134677e63d45429b307709c569",
+  "originHash" : "79acd8672b13f4d188e7a4c5d86093adfa71839a04733296d715993c9f62ce99",
   "pins" : [
     {
       "identity" : "async-http-client",

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,10 @@ let package = Package(
                     package: "container"
                 ),
                 .product(
+                    name: "ContainerXPC",
+                    package: "container"
+                ),
+                .product(
                     name: "ArgumentParser",
                     package: "swift-argument-parser"
                 ),

--- a/Sources/Container-Compose/Codable Structs/Healthcheck.swift
+++ b/Sources/Container-Compose/Codable Structs/Healthcheck.swift
@@ -25,6 +25,17 @@ import Foundation
 
 /// Healthcheck configuration for a service.
 public struct Healthcheck: Codable, Hashable {
+    private static let durationUnits: [String: TimeInterval] = [
+        "ns": 0.000000001,
+        "us": 0.000001,
+        "µs": 0.000001,
+        "ms": 0.001,
+        "s": 1,
+        "m": 60,
+        "h": 3600,
+    ]
+    private static let durationRegex = try! NSRegularExpression(pattern: #"([0-9]+(?:\.[0-9]+)?)(ns|us|µs|ms|s|m|h)"#)
+
     /// Command to run to check health
     public let test: [String]?
     /// Grace period for the container to start
@@ -98,19 +109,8 @@ public struct Healthcheck: Codable, Hashable {
             return seconds
         }
 
-        let units: [String: TimeInterval] = [
-            "ns": 0.000000001,
-            "us": 0.000001,
-            "µs": 0.000001,
-            "ms": 0.001,
-            "s": 1,
-            "m": 60,
-            "h": 3600,
-        ]
-        let pattern = #"([0-9]+(?:\.[0-9]+)?)(ns|us|µs|ms|s|m|h)"#
-        let regex = try! NSRegularExpression(pattern: pattern)
         let range = NSRange(value.startIndex..<value.endIndex, in: value)
-        let matches = regex.matches(in: value, range: range)
+        let matches = Self.durationRegex.matches(in: value, range: range)
         guard !matches.isEmpty else {
             return defaultValue
         }
@@ -123,7 +123,7 @@ public struct Healthcheck: Codable, Hashable {
             else {
                 return total
             }
-            return total + amount * (units[String(value[unitRange])] ?? 0)
+            return total + amount * (Self.durationUnits[String(value[unitRange])] ?? 0)
         }
     }
 }

--- a/Sources/Container-Compose/Codable Structs/Healthcheck.swift
+++ b/Sources/Container-Compose/Codable Structs/Healthcheck.swift
@@ -21,6 +21,7 @@
 //  Created by Morris Richman on 6/17/25.
 //
 
+import Foundation
 
 /// Healthcheck configuration for a service.
 public struct Healthcheck: Codable, Hashable {
@@ -65,5 +66,64 @@ public struct Healthcheck: Codable, Hashable {
         self.interval = try container.decodeIfPresent(String.self, forKey: .interval)
         self.retries = try container.decodeIfPresent(Int.self, forKey: .retries)
         self.timeout = try container.decodeIfPresent(String.self, forKey: .timeout)
+    }
+
+    public var isDisabled: Bool {
+        test?.first?.uppercased() == "NONE"
+    }
+
+    public var execArguments: [String]? {
+        guard let test, !test.isEmpty, !isDisabled else {
+            return nil
+        }
+
+        switch test[0].uppercased() {
+        case "CMD":
+            let command = Array(test.dropFirst())
+            return command.isEmpty ? nil : command
+        case "CMD-SHELL":
+            let command = test.dropFirst().joined(separator: " ")
+            return command.isEmpty ? nil : ["sh", "-c", command]
+        default:
+            return test
+        }
+    }
+
+    public static func parseDuration(_ value: String?, default defaultValue: TimeInterval) -> TimeInterval {
+        guard let value, !value.isEmpty else {
+            return defaultValue
+        }
+
+        if let seconds = TimeInterval(value) {
+            return seconds
+        }
+
+        let units: [String: TimeInterval] = [
+            "ns": 0.000000001,
+            "us": 0.000001,
+            "µs": 0.000001,
+            "ms": 0.001,
+            "s": 1,
+            "m": 60,
+            "h": 3600,
+        ]
+        let pattern = #"([0-9]+(?:\.[0-9]+)?)(ns|us|µs|ms|s|m|h)"#
+        let regex = try! NSRegularExpression(pattern: pattern)
+        let range = NSRange(value.startIndex..<value.endIndex, in: value)
+        let matches = regex.matches(in: value, range: range)
+        guard !matches.isEmpty else {
+            return defaultValue
+        }
+
+        return matches.reduce(0) { total, match in
+            guard
+                let amountRange = Range(match.range(at: 1), in: value),
+                let unitRange = Range(match.range(at: 2), in: value),
+                let amount = TimeInterval(value[amountRange])
+            else {
+                return total
+            }
+            return total + amount * (units[String(value[unitRange])] ?? 0)
+        }
     }
 }

--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -59,6 +59,9 @@ public struct Service: Codable, Hashable {
     /// Services this service depends on (for startup order)
     public let depends_on: [String]?
 
+    /// Service dependency options keyed by dependency service name.
+    public let dependencyConditions: [String: ServiceDependency]?
+
     /// User or UID to run the container as
     public let user: String?
 
@@ -73,6 +76,9 @@ public struct Service: Codable, Hashable {
 
     /// List of networks the service will connect to
     public let networks: [String]?
+
+    /// Service network options keyed by network name.
+    public let networkConfigurations: [String: ServiceNetwork]?
 
     /// Container hostname
     public let hostname: String?
@@ -126,10 +132,12 @@ public struct Service: Codable, Hashable {
         ports: [String]? = nil,
         command: [String]? = nil,
         depends_on: [String]? = nil,
+        dependencyConditions: [String: ServiceDependency]? = nil,
         user: String? = nil,
         container_name: String? = nil,
         labels: [String: String]? = nil,
         networks: [String]? = nil,
+        networkConfigurations: [String: ServiceNetwork]? = nil,
         hostname: String? = nil,
         entrypoint: [String]? = nil,
         privileged: Bool? = nil,
@@ -153,10 +161,12 @@ public struct Service: Codable, Hashable {
         self.ports = ports
         self.command = command
         self.depends_on = depends_on
+        self.dependencyConditions = dependencyConditions
         self.user = user
         self.container_name = container_name
         self.labels = labels
         self.networks = networks
+        self.networkConfigurations = networkConfigurations
         self.hostname = hostname
         self.entrypoint = entrypoint
         self.privileged = privileged
@@ -222,20 +232,33 @@ public struct Service: Codable, Hashable {
         
         if let dependsOnString = try? container.decodeIfPresent(String.self, forKey: .depends_on) {
             depends_on = [dependsOnString]
+            dependencyConditions = [dependsOnString: ServiceDependency()]
         } else if let dependsOnArray = try? container.decodeIfPresent([String].self, forKey: .depends_on) {
             depends_on = dependsOnArray
-        } else if let dependsOnMap = try? container.decodeIfPresent([String: [String: String]].self, forKey: .depends_on) {
-            // Map form: depends_on: { db: { condition: service_healthy } }
-            // Preserve dependency order; conditions are not applicable to Apple Container.
-            depends_on = dependsOnMap.keys.sorted()
+            dependencyConditions = Dictionary(uniqueKeysWithValues: dependsOnArray.map { ($0, ServiceDependency()) })
+        } else if let dependsOnMap = try? container.decodeIfPresent([String: ServiceDependency?].self, forKey: .depends_on) {
+            let normalized = dependsOnMap.mapValues { $0 ?? ServiceDependency() }
+            depends_on = normalized.keys.sorted()
+            dependencyConditions = normalized
         } else {
             depends_on = nil
+            dependencyConditions = nil
         }
         user = try container.decodeIfPresent(String.self, forKey: .user)
 
         container_name = try container.decodeIfPresent(String.self, forKey: .container_name)
         labels = try container.decodeIfPresent([String: String].self, forKey: .labels)
-        networks = try container.decodeIfPresent([String].self, forKey: .networks)
+        if let networkArray = try? container.decodeIfPresent([String].self, forKey: .networks) {
+            networks = networkArray
+            networkConfigurations = Dictionary(uniqueKeysWithValues: networkArray.map { ($0, ServiceNetwork()) })
+        } else if let networkMap = try? container.decodeIfPresent([String: ServiceNetwork?].self, forKey: .networks) {
+            let normalized = networkMap.mapValues { $0 ?? ServiceNetwork() }
+            networks = normalized.keys.sorted()
+            networkConfigurations = normalized
+        } else {
+            networks = nil
+            networkConfigurations = nil
+        }
         hostname = try container.decodeIfPresent(String.self, forKey: .hostname)
         
         // Decode 'entrypoint' which can be either a single string or an array of strings.

--- a/Sources/Container-Compose/Codable Structs/ServiceDependency.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceDependency.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Service-level `depends_on` options for Compose map-form dependencies.
+public struct ServiceDependency: Codable, Hashable {
+    public static let serviceStarted = "service_started"
+    public static let serviceHealthy = "service_healthy"
+    public static let serviceCompletedSuccessfully = "service_completed_successfully"
+
+    /// Dependency condition, for example `service_started` or `service_healthy`.
+    public let condition: String?
+
+    /// Compose optional restart hint for dependency updates.
+    public let restart: Bool?
+
+    /// Compose optional required hint. Defaults to true in Docker Compose.
+    public let required: Bool?
+
+    public var effectiveCondition: String {
+        condition ?? Self.serviceStarted
+    }
+
+    public init(
+        condition: String? = nil,
+        restart: Bool? = nil,
+        required: Bool? = nil
+    ) {
+        self.condition = condition
+        self.restart = restart
+        self.required = required
+    }
+}

--- a/Sources/Container-Compose/Codable Structs/ServiceNetwork.swift
+++ b/Sources/Container-Compose/Codable Structs/ServiceNetwork.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Service-specific network options for Compose object-form networks.
+public struct ServiceNetwork: Codable, Hashable {
+    /// Additional DNS aliases requested for this service on the network.
+    public let aliases: [String]?
+
+    /// Static IPv4 address requested by the Compose file.
+    public let ipv4_address: String?
+
+    /// Static IPv6 address requested by the Compose file.
+    public let ipv6_address: String?
+
+    public init(
+        aliases: [String]? = nil,
+        ipv4_address: String? = nil,
+        ipv6_address: String? = nil
+    ) {
+        self.aliases = aliases
+        self.ipv4_address = ipv4_address
+        self.ipv6_address = ipv6_address
+    }
+}

--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -269,6 +269,36 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         )
     }
 
+    static func networkRunArg(
+        network: String,
+        aliases: [String],
+        serviceName: String,
+        environmentVariables: [String: String],
+        supportsAliases: Bool = supportsNetworkAliases()
+    ) -> (arg: String, warning: String?) {
+        let resolvedAliases = aliases.map { resolveVariable($0, with: environmentVariables) }
+        guard !resolvedAliases.isEmpty else {
+            return (network, nil)
+        }
+
+        if supportsAliases {
+            let aliasProperties = resolvedAliases.map { "alias=\($0)" }.joined(separator: ",")
+            return ("\(network),\(aliasProperties)", nil)
+        }
+
+        return (
+            network,
+            "Warning: Service '\(serviceName)' defines network aliases for '\(network)' (\(resolvedAliases.joined(separator: ", "))), but the linked Apple Container command parser does not expose a container run alias property."
+        )
+    }
+
+    private static func supportsNetworkAliases() -> Bool {
+        (try? Application.ContainerRun.parse([
+            "--network", "container-compose-probe,alias=container-compose-probe",
+            "alpine:latest",
+        ])) != nil
+    }
+
     private func getIPForRunningService(_ serviceName: String) async throws -> String? {
         guard let projectName else { return nil }
 
@@ -574,12 +604,15 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
                 // Use the explicit network name from top-level definition if available, otherwise resolved name
                 let networkToConnect = dockerCompose.networks?[network]??.name ?? resolvedNetwork
                 runCommandArgs.append("--network")
-                runCommandArgs.append(networkToConnect)
-
-                if let aliases = service.networkConfigurations?[network]?.aliases, !aliases.isEmpty {
-                    print(
-                        "Warning: Service '\(serviceName)' defines network aliases for '\(network)' (\(aliases.joined(separator: ", "))), but Apple Container does not currently expose a container run alias flag."
-                    )
+                let networkTranslation = Self.networkRunArg(
+                    network: networkToConnect,
+                    aliases: service.networkConfigurations?[network]?.aliases ?? [],
+                    serviceName: serviceName,
+                    environmentVariables: environmentVariables
+                )
+                runCommandArgs.append(networkTranslation.arg)
+                if let warning = networkTranslation.warning {
+                    print(warning)
                 }
             }
             print(

--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -24,6 +24,7 @@
 import ArgumentParser
 import ContainerCommands
 import ContainerAPIClient
+import ContainerXPC
 import ContainerizationExtras
 import Foundation
 @preconcurrency import Rainbow
@@ -36,6 +37,8 @@ private enum ServiceStartState: Codable, Equatable {
 
 public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
     public init() {}
+
+    private static let networkAliasesSupported = supportsNetworkAliases()
 
     public static let configuration: CommandConfiguration = .init(
         commandName: "up",
@@ -141,7 +144,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             projectName = name
             print("Info: Docker Compose project name parsed as: \(name)")
             print(
-                "Note: The 'name' field currently only affects container naming (e.g., '\(name)-serviceName'). Full project-level isolation for other resources (networks, implicit volumes) is not implemented by this tool."
+                "Note: The 'name' field affects generated container names and default named-volume names. Full project-level isolation for other resources is not implemented by this tool."
             )
         } else {
             projectName = deriveProjectName(cwd: cwd)
@@ -156,11 +159,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         services = try Service.topoSortConfiguredServices(services)
 
         // Filter for specified services
-        if !self.services.isEmpty {
-            services = services.filter({ serviceName, service in
-                self.services.contains(where: { $0 == serviceName }) || self.services.contains(where: { service.dependedBy.contains($0) })
-            })
-        }
+        services = Self.servicesSelectedForUp(services, requestedServices: self.services)
 
         // Stop Services
         try await stopOldStuff(services.map({ $0.serviceName }), remove: true)
@@ -274,7 +273,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         aliases: [String],
         serviceName: String,
         environmentVariables: [String: String],
-        supportsAliases: Bool = supportsNetworkAliases()
+        supportsAliases: Bool = networkAliasesSupported
     ) -> (arg: String, warning: String?) {
         let resolvedAliases = ([serviceName] + aliases.map { resolveVariable($0, with: environmentVariables) })
             .reduce(into: [String]()) { result, alias in
@@ -298,6 +297,40 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             "--network", "container-compose-probe,alias=container-compose-probe",
             "alpine:latest",
         ])) != nil
+    }
+
+    static func servicesSelectedForUp(
+        _ services: [(serviceName: String, service: Service)],
+        requestedServices: [String]
+    ) -> [(serviceName: String, service: Service)] {
+        guard !requestedServices.isEmpty else {
+            return services
+        }
+
+        let servicesByName = Dictionary(uniqueKeysWithValues: services.map { ($0.serviceName, $0.service) })
+        var selected = Set<String>()
+
+        func include(_ serviceName: String) {
+            guard let service = servicesByName[serviceName], selected.insert(serviceName).inserted else {
+                return
+            }
+
+            for dependency in service.depends_on ?? [] {
+                include(dependency)
+            }
+        }
+
+        for serviceName in requestedServices {
+            include(serviceName)
+        }
+
+        return services.filter { selected.contains($0.serviceName) }
+    }
+
+    static func validateStoppedServiceExitCode(_ exitCode: Int32, serviceName: String) throws {
+        guard exitCode == 0 else {
+            throw ComposeError.containerRunFailed(serviceName, exitCode)
+        }
     }
 
     private func getIPForRunningService(_ serviceName: String) async throws -> String? {
@@ -334,6 +367,8 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
                 return .running
             }
             if container?.status == .stopped {
+                let exitCode = try await Self.waitForInitExitCode(containerName: containerName)
+                try Self.validateStoppedServiceExitCode(exitCode, serviceName: serviceName)
                 return .completed
             }
         }
@@ -343,6 +378,16 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             userInfo: [
                 NSLocalizedDescriptionKey: "Timed out waiting for container '\(containerName)' to start."
             ])
+    }
+
+    private static func waitForInitExitCode(containerName: String) async throws -> Int32 {
+        let request = XPCMessage(route: .containerWait)
+        request.set(key: .id, value: containerName)
+        request.set(key: .processIdentifier, value: containerName)
+
+        let client = XPCClient(service: "com.apple.container.apiserver")
+        let response = try await client.send(request, responseTimeout: .seconds(10))
+        return Int32(response.int64(key: .exitCode))
     }
 
     private func stopOldStuff(_ services: [String], remove: Bool) async throws {
@@ -380,7 +425,11 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
     }
 
     private func createVolume(name volumeName: String, config volumeConfig: Volume) async throws {
-        let actualVolumeName = volumeConfig.name ?? volumeConfig.external?.name ?? volumeName
+        let actualVolumeName = composeNamedVolumeName(
+            source: volumeName,
+            projectName: projectName,
+            volumeDefinition: volumeConfig
+        )
 
         if volumeConfig.external?.isExternal == true {
             print("Info: Volume '\(volumeName)' is declared as external.")

--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -35,6 +35,26 @@ private enum ServiceStartState: Codable, Equatable {
     case completed
 }
 
+// `containerWait` must be registered while the runtime client is still alive;
+// once a fast one-shot reaches `.stopped`, the server can no longer recover it.
+private actor ServiceExitCodeRegistry {
+    static let shared = ServiceExitCodeRegistry()
+
+    private var tasks: [String: Task<Int32, Error>] = [:]
+
+    func set(_ task: Task<Int32, Error>, for containerName: String) {
+        tasks[containerName] = task
+    }
+
+    func task(for containerName: String) -> Task<Int32, Error>? {
+        tasks[containerName]
+    }
+
+    func remove(for containerName: String) {
+        tasks[containerName] = nil
+    }
+}
+
 public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
     public init() {}
 
@@ -481,7 +501,13 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
                 return .running
             }
             if container?.status == .stopped {
-                let exitCode = try await Self.waitForInitExitCode(containerName: containerName)
+                let exitCode: Int32
+                if let exitCodeTask = await ServiceExitCodeRegistry.shared.task(for: containerName) {
+                    exitCode = try await exitCodeTask.value
+                    await ServiceExitCodeRegistry.shared.remove(for: containerName)
+                } else {
+                    exitCode = try await Self.waitForInitExitCode(containerName: containerName)
+                }
                 try Self.validateStoppedServiceExitCode(exitCode, serviceName: serviceName)
                 return .completed
             }
@@ -976,6 +1002,10 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             guard exitCode == 0 else {
                 throw ComposeError.containerRunFailed(serviceName, exitCode)
             }
+            let detachedContainerName = containerName
+            await ServiceExitCodeRegistry.shared.set(Task {
+                try await Self.waitForInitExitCode(containerName: detachedContainerName)
+            }, for: detachedContainerName)
         } else {
             Task { [self, selectedColor, activity] in
                 @Sendable

--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -29,6 +29,11 @@ import Foundation
 @preconcurrency import Rainbow
 import Yams
 
+private enum ServiceStartState: Codable, Equatable {
+    case running
+    case completed
+}
+
 public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
     public init() {}
 
@@ -101,6 +106,8 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
     private var projectName: String?
     private var environmentVariables: [String: String] = [:]
     private var containerIps: [String: String] = [:]
+    private var serviceStartStates: [String: ServiceStartState] = [:]
+    private var serviceHealth: [String: Bool] = [:]
     private var containerConsoleColors: [String: NamedColor] = [:]
 
     private static let availableContainerConsoleColors: Set<NamedColor> = [
@@ -174,7 +181,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             print("\n--- Processing Volumes ---")
             for (volumeName, volumeConfig) in volumes {
                 guard let volumeConfig else { continue }
-                await createVolumeHardLink(name: volumeName, config: volumeConfig)
+                try await createVolume(name: volumeName, config: volumeConfig)
             }
             print("--- Volumes Processed ---\n")
         }
@@ -246,6 +253,22 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         return (entrypointFlag, positional)
     }
 
+    static func hostnameRunArgs(
+        hostname: String?,
+        serviceName: String,
+        environmentVariables: [String: String]
+    ) -> (args: [String], warning: String?) {
+        guard let hostname else {
+            return ([], nil)
+        }
+
+        let resolvedHostname = resolveVariable(hostname, with: environmentVariables)
+        return (
+            [],
+            "Warning: Service '\(serviceName)' defines hostname '\(resolvedHostname)', but Apple Container does not currently expose a container run hostname flag."
+        )
+    }
+
     private func getIPForRunningService(_ serviceName: String) async throws -> String? {
         guard let projectName else { return nil }
 
@@ -261,14 +284,13 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         return ip
     }
 
-    /// Repeatedly checks `container list -a` until the given container is listed as `running`.
+    /// Repeatedly checks `container list -a` until the given container is listed as `running` or `stopped`.
     /// - Parameters:
     ///   - containerName: The exact name of the container (e.g. "Assignment-Manager-API-db").
     ///   - timeout: Max seconds to wait before failing.
     ///   - interval: How often to poll (in seconds).
-    /// - Returns: `true` if the container reached "running" state within the timeout.
-    private func waitUntilServiceIsRunning(_ serviceName: String, timeout: TimeInterval = 30, interval: TimeInterval = 0.5) async throws {
-        guard let projectName else { return }
+    private func waitUntilServiceStarted(_ serviceName: String, timeout: TimeInterval = 30, interval: TimeInterval = 0.5) async throws -> ServiceStartState {
+        guard let projectName else { throw ComposeError.invalidProjectName }
         let containerName = "\(projectName)-\(serviceName)"
 
         let deadline = Date().addingTimeInterval(timeout)
@@ -278,14 +300,17 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
             let container = try? await client.get(id: containerName)
             if container?.status == .running {
-                return
+                return .running
+            }
+            if container?.status == .stopped {
+                return .completed
             }
         }
 
         throw NSError(
             domain: "ContainerWait", code: 1,
             userInfo: [
-                NSLocalizedDescriptionKey: "Timed out waiting for container '\(containerName)' to be running."
+                NSLocalizedDescriptionKey: "Timed out waiting for container '\(containerName)' to start."
             ])
     }
 
@@ -323,17 +348,28 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         }
     }
 
-    private func createVolumeHardLink(name volumeName: String, config volumeConfig: Volume) async {
-        guard let projectName else { return }
-        let actualVolumeName = volumeConfig.name ?? volumeName  // Use explicit name or key as name
+    private func createVolume(name volumeName: String, config volumeConfig: Volume) async throws {
+        let actualVolumeName = volumeConfig.name ?? volumeConfig.external?.name ?? volumeName
 
-        let volumeUrl = URL.homeDirectory.appending(path: ".containers/Volumes/\(projectName)/\(actualVolumeName)")
-        let volumePath = volumeUrl.path(percentEncoded: false)
+        if volumeConfig.external?.isExternal == true {
+            print("Info: Volume '\(volumeName)' is declared as external.")
+            print("This tool assumes external volume '\(actualVolumeName)' already exists and will not attempt to create it.")
+            return
+        }
 
-        print(
-            "Warning: Volume source '\(actualVolumeName)' appears to be a named volume reference. The 'container' tool does not support named volume references in 'container run -v' command. Linking to \(volumePath) instead."
+        if (try? await ClientVolume.inspect(actualVolumeName)) != nil {
+            print("Volume '\(actualVolumeName)' already exists")
+            return
+        }
+
+        print("Creating volume: \(volumeName) (Actual name: \(actualVolumeName))")
+        _ = try await ClientVolume.create(
+            name: actualVolumeName,
+            driver: volumeConfig.driver ?? "local",
+            driverOpts: volumeConfig.driver_opts ?? [:],
+            labels: volumeConfig.labels ?? [:]
         )
-        try? fileManager.createDirectory(atPath: volumePath, withIntermediateDirectories: true)
+        print("Volume '\(actualVolumeName)' created")
     }
 
     private func setupNetwork(name networkName: String, config networkConfig: Network?) async throws {
@@ -343,7 +379,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             print("Info: Network '\(networkName)' is declared as external.")
             print("This tool assumes external network '\(externalNetwork.name ?? actualNetworkName)' already exists and will not attempt to create it.")
         } else {
-            var networkCreateArgs: [String] = ["network", "create"]
+            let networkCreateArgs: [String] = ["network", "create"]
 
             #warning("Docker Compose Network Options Not Supported")
             // Add driver and driver options
@@ -400,6 +436,8 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
     // MARK: Compose Service Level Functions
     private mutating func configService(_ service: Service, serviceName: String, from dockerCompose: DockerCompose) async throws {
         guard let projectName else { throw ComposeError.invalidProjectName }
+
+        try waitForDependencyConditions(serviceName: serviceName, service: service)
 
         var imageToRun: String
         
@@ -477,7 +515,7 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         // Add volume mounts
         if let volumes = service.volumes {
             for volume in volumes {
-                let args = try await configVolume(volume)
+                let args = try await configVolume(volume, from: dockerCompose)
                 runCommandArgs.append(contentsOf: args)
             }
         }
@@ -537,6 +575,12 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
                 let networkToConnect = dockerCompose.networks?[network]??.name ?? resolvedNetwork
                 runCommandArgs.append("--network")
                 runCommandArgs.append(networkToConnect)
+
+                if let aliases = service.networkConfigurations?[network]?.aliases, !aliases.isEmpty {
+                    print(
+                        "Warning: Service '\(serviceName)' defines network aliases for '\(network)' (\(aliases.joined(separator: ", "))), but Apple Container does not currently expose a container run alias flag."
+                    )
+                }
             }
             print(
                 "Info: Service '\(serviceName)' is configured to connect to networks: \(serviceNetworks.joined(separator: ", ")) ascertained from networks attribute in \(composePath)."
@@ -548,12 +592,16 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             print("Note: Service '\(serviceName)' is not explicitly connected to any networks. It will likely use the default bridge network.")
         }
 
-        // Add hostname
-        if let hostname = service.hostname {
-            let resolvedHostname = resolveVariable(hostname, with: environmentVariables)
-            runCommandArgs.append("--hostname")
-            runCommandArgs.append(resolvedHostname)
+        // Apple Container 1.0.0 does not expose a `container run` hostname flag.
+        let hostnameTranslation = Self.hostnameRunArgs(
+            hostname: service.hostname,
+            serviceName: serviceName,
+            environmentVariables: environmentVariables
+        )
+        if let warning = hostnameTranslation.warning {
+            print(warning)
         }
+        runCommandArgs.append(contentsOf: hostnameTranslation.args)
 
         // Add working directory
         if let workingDir = service.working_dir {
@@ -636,26 +684,120 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
             }
         }
 
-        self.containerConsoleColors[serviceName] = serviceColor
+        let selectedColor = serviceColor
+        self.containerConsoleColors[serviceName] = selectedColor
 
-        Task { [self, serviceColor] in
-            @Sendable
-            func handleOutput(_ output: String) {
-                print("\(serviceName): \(output)".applyingColor(serviceColor))
-            }
+        @Sendable
+        func handleOutput(_ output: String) {
+            print("\(serviceName): \(output)".applyingColor(selectedColor))
+        }
 
+        if detach {
             print("\nStarting service: \(serviceName)")
             print("Starting \(serviceName)")
             print("----------------------------------------\n")
-            let _ = try await streamCommand("container", args: ["run"] + runCommandArgs, onStdout: handleOutput, onStderr: handleOutput)
+            let exitCode = try await streamCommand(
+                "container",
+                args: ["run"] + runCommandArgs,
+                onStdout: handleOutput,
+                onStderr: handleOutput
+            )
+            guard exitCode == 0 else {
+                throw ComposeError.containerRunFailed(serviceName, exitCode)
+            }
+        } else {
+            Task { [self, selectedColor] in
+                @Sendable
+                func handleOutput(_ output: String) {
+                    print("\(serviceName): \(output)".applyingColor(selectedColor))
+                }
+
+                print("\nStarting service: \(serviceName)")
+                print("Starting \(serviceName)")
+                print("----------------------------------------\n")
+                let exitCode = try await streamCommand(
+                    "container",
+                    args: ["run"] + runCommandArgs,
+                    onStdout: handleOutput,
+                    onStderr: handleOutput
+                )
+                if exitCode != 0 {
+                    fputs("Error: Service '\(serviceName)' exited with status \(exitCode).\n", stderr)
+                }
+            }
         }
 
-        do {
-            try await waitUntilServiceIsRunning(serviceName)
+        let startState = try await waitUntilServiceStarted(serviceName)
+        serviceStartStates[serviceName] = startState
+
+        switch startState {
+        case .running:
             try await updateEnvironmentWithServiceIP(serviceName)
-        } catch {
-            print(error)
+            if let healthcheck = service.healthcheck, !healthcheck.isDisabled {
+                try await waitUntilServiceIsHealthy(serviceName: serviceName, healthcheck: healthcheck)
+                serviceHealth[serviceName] = true
+            }
+        case .completed:
+            if let healthcheck = service.healthcheck, !healthcheck.isDisabled {
+                throw ComposeError.healthcheckUnavailable(serviceName)
+            }
         }
+    }
+
+    private func waitForDependencyConditions(serviceName: String, service: Service) throws {
+        for dependencyName in service.depends_on ?? [] {
+            let dependency = service.dependencyConditions?[dependencyName] ?? ServiceDependency()
+            switch dependency.effectiveCondition {
+            case ServiceDependency.serviceStarted:
+                guard serviceStartStates[dependencyName] != nil else {
+                    throw ComposeError.dependencyNotStarted(serviceName, dependencyName)
+                }
+            case ServiceDependency.serviceHealthy:
+                guard serviceHealth[dependencyName] == true else {
+                    throw ComposeError.dependencyNotHealthy(serviceName, dependencyName)
+                }
+            case ServiceDependency.serviceCompletedSuccessfully:
+                guard serviceStartStates[dependencyName] == .completed else {
+                    throw ComposeError.dependencyNotCompleted(serviceName, dependencyName)
+                }
+            default:
+                throw ComposeError.unsupportedDependencyCondition(serviceName, dependencyName, dependency.effectiveCondition)
+            }
+        }
+    }
+
+    private func waitUntilServiceIsHealthy(serviceName: String, healthcheck: Healthcheck) async throws {
+        guard let projectName else { throw ComposeError.invalidProjectName }
+        guard let execArguments = healthcheck.execArguments else {
+            return
+        }
+
+        let containerName = "\(projectName)-\(serviceName)"
+        let retries = max(healthcheck.retries ?? 3, 1)
+        let interval = Healthcheck.parseDuration(healthcheck.interval, default: 30)
+        let startPeriod = Healthcheck.parseDuration(healthcheck.start_period, default: 0)
+
+        if startPeriod > 0 {
+            try await Task.sleep(nanoseconds: UInt64(startPeriod * 1_000_000_000))
+        }
+
+        for attempt in 1...retries {
+            let exitCode = try await streamCommand(
+                "container",
+                args: ["exec", containerName] + execArguments,
+                onStdout: { _ in },
+                onStderr: { _ in }
+            )
+            if exitCode == 0 {
+                return
+            }
+
+            if attempt < retries {
+                try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+            }
+        }
+
+        throw ComposeError.healthcheckFailed(serviceName)
     }
 
     private func pullImage(_ imageName: String, platform: String?) async throws {
@@ -751,8 +893,15 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         return imageToRun
     }
 
-    private func configVolume(_ volume: String) async throws -> [String] {
-        try composeVolumeToRunArgs(volume, cwd: cwd, fileManager: fileManager, environmentVariables: environmentVariables, projectName: projectName)
+    private func configVolume(_ volume: String, from dockerCompose: DockerCompose) async throws -> [String] {
+        try composeVolumeToRunArgs(
+            volume,
+            cwd: cwd,
+            fileManager: fileManager,
+            environmentVariables: environmentVariables,
+            projectName: projectName,
+            volumeDefinitions: dockerCompose.volumes
+        )
     }
 }
 

--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -276,10 +276,11 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         environmentVariables: [String: String],
         supportsAliases: Bool = supportsNetworkAliases()
     ) -> (arg: String, warning: String?) {
-        let resolvedAliases = aliases.map { resolveVariable($0, with: environmentVariables) }
-        guard !resolvedAliases.isEmpty else {
-            return (network, nil)
-        }
+        let resolvedAliases = ([serviceName] + aliases.map { resolveVariable($0, with: environmentVariables) })
+            .reduce(into: [String]()) { result, alias in
+                guard !alias.isEmpty, !result.contains(alias) else { return }
+                result.append(alias)
+            }
 
         if supportsAliases {
             let aliasProperties = resolvedAliases.map { "alias=\($0)" }.joined(separator: ",")

--- a/Sources/Container-Compose/Errors.swift
+++ b/Sources/Container-Compose/Errors.swift
@@ -39,6 +39,13 @@ public enum YamlError: Error, LocalizedError {
 public enum ComposeError: Error, LocalizedError {
     case imageNotFound(String)
     case invalidProjectName
+    case containerRunFailed(String, Int32)
+    case dependencyNotStarted(String, String)
+    case dependencyNotHealthy(String, String)
+    case dependencyNotCompleted(String, String)
+    case unsupportedDependencyCondition(String, String, String)
+    case healthcheckUnavailable(String)
+    case healthcheckFailed(String)
 
     public var errorDescription: String? {
         switch self {
@@ -46,6 +53,20 @@ public enum ComposeError: Error, LocalizedError {
             return "Service \(name) must define either 'image' or 'build'."
         case .invalidProjectName:
             return "Could not find project name."
+        case .containerRunFailed(let service, let exitCode):
+            return "Service '\(service)' failed to start (container run exited with status \(exitCode))."
+        case .dependencyNotStarted(let service, let dependency):
+            return "Service '\(service)' depends on '\(dependency)', but '\(dependency)' has not started."
+        case .dependencyNotHealthy(let service, let dependency):
+            return "Service '\(service)' depends on '\(dependency)' with condition 'service_healthy', but '\(dependency)' is not healthy."
+        case .dependencyNotCompleted(let service, let dependency):
+            return "Service '\(service)' depends on '\(dependency)' with condition 'service_completed_successfully', but '\(dependency)' has not completed successfully."
+        case .unsupportedDependencyCondition(let service, let dependency, let condition):
+            return "Service '\(service)' depends on '\(dependency)' with unsupported condition '\(condition)'."
+        case .healthcheckUnavailable(let service):
+            return "Service '\(service)' defines a healthcheck but completed before the healthcheck could run."
+        case .healthcheckFailed(let service):
+            return "Service '\(service)' failed its healthcheck."
         }
     }
 }

--- a/Sources/Container-Compose/Helper Functions.swift
+++ b/Sources/Container-Compose/Helper Functions.swift
@@ -160,7 +160,8 @@ func composeVolumeToRunArgs(
     cwd: String,
     fileManager: FileManager = .default,
     environmentVariables: [String: String] = [:],
-    projectName: String?
+    projectName: String?,
+    volumeDefinitions: [String: Volume?]? = nil
 ) throws -> [String] {
     let resolvedVolume = resolveVariable(volume, with: environmentVariables)
     var args: [String] = []
@@ -197,20 +198,11 @@ func composeVolumeToRunArgs(
             }
         }
     } else {
-        guard let projectName else { return [] }
-        let volumeUrl = URL.homeDirectory.appending(path: ".containers/Volumes/\(projectName)/\(source)")
-        let volumePath = volumeUrl.path(percentEncoded: false)
-        let destinationUrl = URL(fileURLWithPath: destination).deletingLastPathComponent()
-        let destinationPath = destinationUrl.path(percentEncoded: false)
-
-        print(
-            "Warning: Volume source '\(source)' appears to be a named volume reference. The 'container' tool does not support named volume references in 'container run -v' command. Linking to \(volumePath) instead."
-        )
-        try fileManager.createDirectory(atPath: volumePath, withIntermediateDirectories: true)
+        let volumeDefinition = volumeDefinitions?[source] ?? nil
+        let actualVolumeName = volumeDefinition?.name ?? volumeDefinition?.external?.name ?? source
 
         args.append("-v")
-        let modeStr = mode.map { ":\($0)" } ?? ""
-        args.append("\(volumePath):\(destinationPath)\(modeStr)")
+        args.append(bindMountArg(source: actualVolumeName))
     }
 
     return args

--- a/Sources/Container-Compose/Helper Functions.swift
+++ b/Sources/Container-Compose/Helper Functions.swift
@@ -199,13 +199,37 @@ func composeVolumeToRunArgs(
         }
     } else {
         let volumeDefinition = volumeDefinitions?[source] ?? nil
-        let actualVolumeName = volumeDefinition?.name ?? volumeDefinition?.external?.name ?? source
+        let actualVolumeName = composeNamedVolumeName(
+            source: source,
+            projectName: projectName,
+            volumeDefinition: volumeDefinition
+        )
 
         args.append("-v")
         args.append(bindMountArg(source: actualVolumeName))
     }
 
     return args
+}
+
+func composeNamedVolumeName(
+    source: String,
+    projectName: String?,
+    volumeDefinition: Volume?
+) -> String {
+    if let explicitName = volumeDefinition?.name {
+        return explicitName
+    }
+
+    if volumeDefinition?.external?.isExternal == true {
+        return volumeDefinition?.external?.name ?? source
+    }
+
+    guard let projectName, !projectName.isEmpty else {
+        return source
+    }
+
+    return "\(projectName)_\(source)"
 }
 
 extension String: @retroactive Error {}

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -227,6 +227,8 @@ struct DockerComposeParsingTests {
         #expect(compose.services["web"]??.depends_on?.contains("db") == true)
         #expect(compose.services["web"]??.depends_on?.contains("cache") == true)
         #expect(compose.services["web"]??.depends_on?.count == 2)
+        #expect(compose.services["web"]??.dependencyConditions?["db"]?.condition == "service_healthy")
+        #expect(compose.services["web"]??.dependencyConditions?["cache"]?.condition == "service_started")
     }
 
     @Test("Parse compose with build context")

--- a/Tests/Container-Compose-StaticTests/EntrypointCommandTests.swift
+++ b/Tests/Container-Compose-StaticTests/EntrypointCommandTests.swift
@@ -107,4 +107,16 @@ struct EntrypointCommandTests {
         #expect(r.entrypointFlag == "/bin/sh")
         #expect(r.positional == [])
     }
+
+    @Test("hostname does not emit unsupported container run flag")
+    func hostnameDoesNotEmitUnsupportedRunFlag() {
+        let r = ComposeUp.hostnameRunArgs(
+            hostname: "${HOSTNAME_VALUE}",
+            serviceName: "web",
+            environmentVariables: ["HOSTNAME_VALUE": "custom-host"]
+        )
+
+        #expect(r.args.isEmpty)
+        #expect(r.warning == "Warning: Service 'web' defines hostname 'custom-host', but Apple Container does not currently expose a container run hostname flag.")
+    }
 }

--- a/Tests/Container-Compose-StaticTests/EntrypointCommandTests.swift
+++ b/Tests/Container-Compose-StaticTests/EntrypointCommandTests.swift
@@ -120,7 +120,7 @@ struct EntrypointCommandTests {
         #expect(r.warning == "Warning: Service 'web' defines hostname 'custom-host', but Apple Container does not currently expose a container run hostname flag.")
     }
 
-    @Test("network aliases emit Apple alias properties when supported")
+    @Test("network aliases emit service name and Apple alias properties when supported")
     func networkAliasesEmitWhenSupported() {
         let r = ComposeUp.networkRunArg(
             network: "backend",
@@ -130,7 +130,35 @@ struct EntrypointCommandTests {
             supportsAliases: true
         )
 
-        #expect(r.arg == "backend,alias=db,alias=database")
+        #expect(r.arg == "backend,alias=web,alias=db,alias=database")
+        #expect(r.warning == nil)
+    }
+
+    @Test("network aliases emit service name when no explicit aliases are configured")
+    func networkAliasesEmitServiceNameByDefault() {
+        let r = ComposeUp.networkRunArg(
+            network: "backend",
+            aliases: [],
+            serviceName: "web",
+            environmentVariables: [:],
+            supportsAliases: true
+        )
+
+        #expect(r.arg == "backend,alias=web")
+        #expect(r.warning == nil)
+    }
+
+    @Test("network aliases do not duplicate explicit service name alias")
+    func networkAliasesDoNotDuplicateServiceName() {
+        let r = ComposeUp.networkRunArg(
+            network: "backend",
+            aliases: ["web", "database"],
+            serviceName: "web",
+            environmentVariables: [:],
+            supportsAliases: true
+        )
+
+        #expect(r.arg == "backend,alias=web,alias=database")
         #expect(r.warning == nil)
     }
 
@@ -145,6 +173,6 @@ struct EntrypointCommandTests {
         )
 
         #expect(r.arg == "backend")
-        #expect(r.warning == "Warning: Service 'web' defines network aliases for 'backend' (db, database), but the linked Apple Container command parser does not expose a container run alias property.")
+        #expect(r.warning == "Warning: Service 'web' defines network aliases for 'backend' (web, db, database), but the linked Apple Container command parser does not expose a container run alias property.")
     }
 }

--- a/Tests/Container-Compose-StaticTests/EntrypointCommandTests.swift
+++ b/Tests/Container-Compose-StaticTests/EntrypointCommandTests.swift
@@ -119,4 +119,32 @@ struct EntrypointCommandTests {
         #expect(r.args.isEmpty)
         #expect(r.warning == "Warning: Service 'web' defines hostname 'custom-host', but Apple Container does not currently expose a container run hostname flag.")
     }
+
+    @Test("network aliases emit Apple alias properties when supported")
+    func networkAliasesEmitWhenSupported() {
+        let r = ComposeUp.networkRunArg(
+            network: "backend",
+            aliases: ["${SERVICE_ALIAS}", "database"],
+            serviceName: "web",
+            environmentVariables: ["SERVICE_ALIAS": "db"],
+            supportsAliases: true
+        )
+
+        #expect(r.arg == "backend,alias=db,alias=database")
+        #expect(r.warning == nil)
+    }
+
+    @Test("network aliases warn when Apple alias properties are unsupported")
+    func networkAliasesWarnWhenUnsupported() {
+        let r = ComposeUp.networkRunArg(
+            network: "backend",
+            aliases: ["${SERVICE_ALIAS}", "database"],
+            serviceName: "web",
+            environmentVariables: ["SERVICE_ALIAS": "db"],
+            supportsAliases: false
+        )
+
+        #expect(r.arg == "backend")
+        #expect(r.warning == "Warning: Service 'web' defines network aliases for 'backend' (db, database), but the linked Apple Container command parser does not expose a container run alias property.")
+    }
 }

--- a/Tests/Container-Compose-StaticTests/HealthcheckConfigurationTests.swift
+++ b/Tests/Container-Compose-StaticTests/HealthcheckConfigurationTests.swift
@@ -132,6 +132,25 @@ struct HealthcheckConfigurationTests {
         
         #expect(healthcheck.test?.first == "CMD-SHELL")
     }
+
+    @Test("Healthcheck CMD translates to exec arguments")
+    func healthcheckCmdExecArguments() throws {
+        let healthcheck = Healthcheck(test: ["CMD", "curl", "-f", "http://localhost"])
+        #expect(healthcheck.execArguments == ["curl", "-f", "http://localhost"])
+    }
+
+    @Test("Healthcheck CMD-SHELL translates to shell exec arguments")
+    func healthcheckCmdShellExecArguments() throws {
+        let healthcheck = Healthcheck(test: ["CMD-SHELL", "curl -f http://localhost || exit 1"])
+        #expect(healthcheck.execArguments == ["sh", "-c", "curl -f http://localhost || exit 1"])
+    }
+
+    @Test("Healthcheck duration parser supports combined units")
+    func healthcheckDurationParser() throws {
+        #expect(Healthcheck.parseDuration("1m30s", default: 0) == 90)
+        #expect(Healthcheck.parseDuration("250ms", default: 0) == 0.25)
+        #expect(Healthcheck.parseDuration(nil, default: 7) == 7)
+    }
     
     @Test("Disable healthcheck")
     func disableHealthcheck() throws {

--- a/Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift
+++ b/Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift
@@ -220,14 +220,14 @@ struct ComposeVolumeTests {
         #expect(result == [])
     }
 
-    @Test("Named volume is forwarded using native container volume syntax")
+    @Test("Named volume is forwarded using project-scoped native container volume syntax")
     func testNamedVolumeUsesNativeVolumeSyntax() throws {
         let result = try composeVolumeToRunArgs(
             "data:/var/lib/postgresql/data",
             cwd: "/tmp",
             projectName: "test"
         )
-        #expect(result == ["-v", "data:/var/lib/postgresql/data"])
+        #expect(result == ["-v", "test_data:/var/lib/postgresql/data"])
     }
 
     @Test("Named volume uses explicit top-level volume name")
@@ -241,6 +241,32 @@ struct ComposeVolumeTests {
             ]
         )
         #expect(result == ["-v", "prod-db-data:/var/lib/postgresql/data:ro"])
+    }
+
+    @Test("External named volume without explicit name keeps source name")
+    func testNamedVolumeKeepsExternalSourceName() throws {
+        let result = try composeVolumeToRunArgs(
+            "db-data:/var/lib/postgresql/data",
+            cwd: "/tmp",
+            projectName: "test",
+            volumeDefinitions: [
+                "db-data": Volume(external: ExternalVolume(isExternal: true, name: nil))
+            ]
+        )
+        #expect(result == ["-v", "db-data:/var/lib/postgresql/data"])
+    }
+
+    @Test("External named volume uses explicit external name")
+    func testNamedVolumeUsesExplicitExternalName() throws {
+        let result = try composeVolumeToRunArgs(
+            "db-data:/var/lib/postgresql/data",
+            cwd: "/tmp",
+            projectName: "test",
+            volumeDefinitions: [
+                "db-data": Volume(external: ExternalVolume(isExternal: true, name: "shared-db-data"))
+            ]
+        )
+        #expect(result == ["-v", "shared-db-data:/var/lib/postgresql/data"])
     }
 
 }

--- a/Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift
+++ b/Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift
@@ -220,4 +220,27 @@ struct ComposeVolumeTests {
         #expect(result == [])
     }
 
+    @Test("Named volume is forwarded using native container volume syntax")
+    func testNamedVolumeUsesNativeVolumeSyntax() throws {
+        let result = try composeVolumeToRunArgs(
+            "data:/var/lib/postgresql/data",
+            cwd: "/tmp",
+            projectName: "test"
+        )
+        #expect(result == ["-v", "data:/var/lib/postgresql/data"])
+    }
+
+    @Test("Named volume uses explicit top-level volume name")
+    func testNamedVolumeUsesExplicitTopLevelName() throws {
+        let result = try composeVolumeToRunArgs(
+            "db-data:/var/lib/postgresql/data:ro",
+            cwd: "/tmp",
+            projectName: "test",
+            volumeDefinitions: [
+                "db-data": Volume(name: "prod-db-data")
+            ]
+        )
+        #expect(result == ["-v", "prod-db-data:/var/lib/postgresql/data:ro"])
+    }
+
 }

--- a/Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift
+++ b/Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift
@@ -230,6 +230,26 @@ struct ComposeVolumeTests {
         #expect(result == ["-v", "test_data:/var/lib/postgresql/data"])
     }
 
+    @Test("Named volume mounts at its declared single-segment destination")
+    func testNamedVolumeMountsAtDeclaredSingleSegmentDestination() throws {
+        let result = try composeVolumeToRunArgs(
+            "redisdata:/data",
+            cwd: "/tmp",
+            projectName: "proj"
+        )
+        #expect(result == ["-v", "proj_redisdata:/data"])
+    }
+
+    @Test("Named volume preserves nested destination and mode")
+    func testNamedVolumePreservesNestedDestinationAndMode() throws {
+        let result = try composeVolumeToRunArgs(
+            "pgdata:/var/lib/postgresql/data:ro",
+            cwd: "/tmp",
+            projectName: "proj"
+        )
+        #expect(result == ["-v", "proj_pgdata:/var/lib/postgresql/data:ro"])
+    }
+
     @Test("Named volume uses explicit top-level volume name")
     func testNamedVolumeUsesExplicitTopLevelName() throws {
         let result = try composeVolumeToRunArgs(

--- a/Tests/Container-Compose-StaticTests/NetworkConfigurationTests.swift
+++ b/Tests/Container-Compose-StaticTests/NetworkConfigurationTests.swift
@@ -65,6 +65,31 @@ struct NetworkConfigurationTests {
         #expect(compose.services["app"]??.networks?.contains("frontend") == true)
         #expect(compose.services["app"]??.networks?.contains("backend") == true)
     }
+
+    @Test("Parse service network object form with aliases")
+    func parseServiceNetworkObjectFormWithAliases() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          web:
+            image: nginx:latest
+            networks:
+              frontend:
+                aliases:
+                  - web.local
+              backend:
+        networks:
+          frontend:
+          backend:
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+
+        #expect(compose.services["web"]??.networks == ["backend", "frontend"])
+        #expect(compose.services["web"]??.networkConfigurations?["frontend"]?.aliases == ["web.local"])
+        #expect(compose.services["web"]??.networkConfigurations?["backend"] != nil)
+    }
     
     @Test("Parse network with driver")
     func parseNetworkWithDriver() throws {
@@ -187,4 +212,3 @@ struct NetworkConfigurationTests {
         #expect(compose.services["web"] != nil)
     }
 }
-

--- a/Tests/Container-Compose-StaticTests/ServiceDependencyTests.swift
+++ b/Tests/Container-Compose-StaticTests/ServiceDependencyTests.swift
@@ -67,6 +67,32 @@ struct ServiceDependencyTests {
         #expect(sorted[1].serviceName == "app")
         #expect(sorted[2].serviceName == "web")
     }
+
+    @Test("Selecting service keeps transitive dependency closure")
+    func selectingServiceKeepsTransitiveDependencyClosure() throws {
+        let worker = Service(image: "worker", depends_on: ["api"])
+        let api = Service(image: "api", depends_on: ["db"])
+        let db = Service(image: "postgres", depends_on: nil)
+        let cache = Service(image: "redis", depends_on: nil)
+
+        let services: [(String, Service)] = [
+            ("worker", worker),
+            ("api", api),
+            ("db", db),
+            ("cache", cache),
+        ]
+        let sorted = try Service.topoSortConfiguredServices(services)
+        let selected = ComposeUp.servicesSelectedForUp(sorted, requestedServices: ["worker"])
+
+        #expect(selected.map(\.serviceName) == ["db", "api", "worker"])
+    }
+
+    @Test("Stopped service non-zero exit code fails startup")
+    func stoppedServiceNonZeroExitCodeFailsStartup() throws {
+        #expect(throws: ComposeError.self) {
+            try ComposeUp.validateStoppedServiceExitCode(17, serviceName: "db")
+        }
+    }
     
     @Test("No dependencies - services should maintain order")
     func noDependencies() throws {
@@ -132,4 +158,3 @@ struct ServiceDependencyTests {
         #expect(sorted.count == 1)
     }
 }
-


### PR DESCRIPTION
## Summary

This improves compatibility with Apple `container` for several Compose workflows:

- decode `depends_on` map form and preserve dependency conditions
- wait for `service_started`, `service_healthy`, and `service_completed_successfully`
- parse service `networks` object form, including aliases
- emit Apple network alias properties when the linked Apple `container` command parser supports them, while preserving a warning/skip fallback for Apple Container 1.0.0
- warn and skip Compose `hostname:` because Apple `container run` 1.0.0 does not currently expose a hostname flag; proposed upstream support remains under discussion in apple/container#1811
- execute supported healthchecks (`CMD` and `CMD-SHELL`) with interval/start-period/retry handling
- create and mount named volumes through native `container volume` support instead of rewriting them into host paths
- surface failed detached `container run` commands as errors, which makes one-shot failures fail `compose up`

Related issues: #52, #115, #116, #117, and tracker #118.

Apple-side service discovery work is tracked upstream in apple/container#1809. Current upstream PR chain:

- apple/container#1810: normalized/trailing-dot hostname lookup, signed and ready for review
- apple/container#1811: optional native `container run --hostname`, signed and under maintainer discussion; aliases may cover most Compose cases
- apple/container#1813: DNS forwarding/message groundwork only; container-facing listener startup was removed after vmnet gateway bind validation failed
- apple/container#1815: network attachment aliases via `--network name,alias=...`, signed, closes apple/container#1839

## Testing

Static/build checks:

```sh
git diff --check
swift build
swift test --filter EntrypointCommandTests
swift test --filter Container_Compose_StaticTests --skip WaitForeverCpuTests
```

The static test command passed 141 tests. `WaitForeverCpuTests` was skipped because the existing CPU-threshold test is noisy on this machine and unrelated to these changes.

Manual Apple `container` smoke tests using the locally built `Container-Compose` binary:

- one-shot success dependency completes and unblocks dependent startup
- one-shot failure exits nonzero and fails `up -d`
- native named volume persists data and can be read from a separate `container run`
- service network object form attaches to the requested network and emits an alias fallback warning against Apple Container 1.0.0
- passing healthcheck unblocks dependent service startup
- failing healthcheck prevents dependent service startup
- service with `hostname:` emits a warning, does not pass unsupported `--hostname`, and completes successfully (`HOSTNAME_OK` logged)

All dynamic test containers, networks, and volumes were cleaned up after the runs.