### PR TITLE
Fix env_file variable parsing on Compose file

### DIFF
--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -192,7 +192,15 @@ public struct Service: Codable, Hashable {
             environment = nil
         }
 
-        env_file = try container.decodeIfPresent([String].self, forKey: .env_file)
+        // Decode 'env_file' which can be either a single string or an array of strings.
+        if let envFileArray = try? container.decodeIfPresent([String].self, forKey: .env_file) {
+            env_file = envFileArray
+        } else if let envFileString = try? container.decodeIfPresent(String.self, forKey: .env_file) {
+            env_file = [envFileString]
+        } else {
+            env_file = nil
+        }
+
         ports = try container.decodeIfPresent([String].self, forKey: .ports)
 
         // Decode 'command' which can be either a single string or an array of strings.

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -141,6 +141,29 @@ struct DockerComposeParsingTests {
         #expect(compose.services["app"]??.environment?["DEBUG"] == "true")
     }
     
+    @Test("Parse compose with env_file")
+    func parseComposeWithEnvFile() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          web:
+            image: nginx:latest
+            env_file: web.env
+          db:
+            image: postgres:14
+            env_file:
+              - db.env
+        """
+        
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+        
+        #expect(compose.services["web"]??.env_file?.count == 1)
+        #expect(compose.services["web"]??.env_file?.contains("web.env") == true)
+        #expect(compose.services["db"]??.env_file?.count == 1)
+        #expect(compose.services["db"]??.env_file?.contains("db.env") == true)
+    }
+    
     @Test("Parse compose with ports")
     func parseComposeWithPorts() throws {
         let yaml = """


### PR DESCRIPTION
In `env_file`, the current Container-Compose implemantion only supports list syntax.
Therefore it rejects following Compose.

```yaml
services:
  app:
    image: alpine:latest
    env_file: app.env
```

According to The Compose Specification, `env_file` supports both string and list syntax.
https://github.com/compose-spec/compose-spec/blob/main/spec.md#env_file

This PR fixes `env_file` parsing in Compose file.