### PR TITLE
Map named volumes to native container volumes (fixes #96)

### DIFF
--- a/Sources/Container-Compose/Helper Functions.swift
+++ b/Sources/Container-Compose/Helper Functions.swift
@@ -198,19 +198,28 @@ func composeVolumeToRunArgs(
         }
     } else {
         guard let projectName else { return [] }
-        let volumeUrl = URL.homeDirectory.appending(path: ".containers/Volumes/\(projectName)/\(source)")
-        let volumePath = volumeUrl.path(percentEncoded: false)
-        let destinationUrl = URL(fileURLWithPath: destination).deletingLastPathComponent()
-        let destinationPath = destinationUrl.path(percentEncoded: false)
 
-        print(
-            "Warning: Volume source '\(source)' appears to be a named volume reference. The 'container' tool does not support named volume references in 'container run -v' command. Linking to \(volumePath) instead."
-        )
-        try fileManager.createDirectory(atPath: volumePath, withIntermediateDirectories: true)
+        // Named volume. As of `container` 1.0.0 these are supported natively
+        // (`container volume`) and are auto-created on first `run`, so we map a
+        // Compose named volume straight to a `container` named volume.
+        //
+        // We deliberately do NOT fall back to bind-mounting a host directory:
+        //   1. Bind mounts use virtiofs, whose mount the guest cannot `chown`.
+        //      Images whose entrypoint chowns its data dir (postgres, redis, …)
+        //      then die with "chown: Operation not permitted". Native volumes are
+        //      block devices the guest owns, so chown works.
+        //   2. The previous host-dir mapping stripped the destination to its parent
+        //      (`destination.deletingLastPathComponent()`), so `redisdata:/data`
+        //      mounted over `/` and shadowed the image's root filesystem (hiding its
+        //      entrypoint). See issue #96.
+        //
+        // The volume is namespaced as `<project>_<source>`, mirroring Docker
+        // Compose, so stacks don't collide on shared volume names.
+        let volumeName = "\(projectName)_\(source)"
 
         args.append("-v")
         let modeStr = mode.map { ":\($0)" } ?? ""
-        args.append("\(volumePath):\(destinationPath)\(modeStr)")
+        args.append("\(volumeName):\(destination)\(modeStr)")
     }
 
     return args

--- a/Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift
+++ b/Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift
@@ -220,4 +220,39 @@ struct ComposeVolumeTests {
         #expect(result == [])
     }
 
+    // MARK: Named volumes (issue #96)
+
+    @Test("Named volume maps to a native, project-namespaced container volume")
+    func testNamedVolumeMapsToNativeVolume() throws {
+        let result = try composeVolumeToRunArgs("redisdata:/data", cwd: "/tmp", projectName: "proj")
+        // `<project>_<source>` native volume mounted at the declared destination.
+        #expect(result == ["-v", "proj_redisdata:/data"])
+    }
+
+    @Test("Named volume mounts at its declared destination, not the parent")
+    func testNamedVolumeMountsAtDestinationNotParent() throws {
+        // Regression for #96: a single-segment destination must NOT collapse to
+        // `/` (which mounted the volume over the image root and hid its entrypoint).
+        let result = try composeVolumeToRunArgs("redisdata:/data", cwd: "/tmp", projectName: "proj")
+        let mount = result.last ?? ""
+        #expect(!mount.hasSuffix(":/"))
+        #expect(mount.hasSuffix(":/data"))
+    }
+
+    @Test("Named volume preserves nested destination and mode")
+    func testNamedVolumeNestedDestinationWithMode() throws {
+        let result = try composeVolumeToRunArgs(
+            "pgdata:/var/lib/postgresql/data:ro",
+            cwd: "/tmp",
+            projectName: "proj"
+        )
+        #expect(result == ["-v", "proj_pgdata:/var/lib/postgresql/data:ro"])
+    }
+
+    @Test("Named volume without a project name is skipped")
+    func testNamedVolumeWithoutProjectNameSkipped() throws {
+        let result = try composeVolumeToRunArgs("redisdata:/data", cwd: "/tmp", projectName: nil)
+        #expect(result == [])
+    }
+
 }


### PR DESCRIPTION
## Problem

The named-volume branch of `composeVolumeToRunArgs` bind-mounted a host directory and mounted it at the **parent** of the declared destination via `destination.deletingLastPathComponent()`. Two failure modes fall out of this:

1. **Mounts over `/` (issue #96).** A single-segment destination collapses to `/`. So `redisdata:/data` mounts the volume over the container's entire root filesystem, shadowing the image's entrypoint. Redis fails to start with:
   ```
   failed to find target executable docker-entrypoint.sh
   ```
2. **No chown on virtiofs.** Even for nested destinations, the host bind mount uses virtiofs, which the guest cannot `chown`. Images whose entrypoint chowns its data directory (postgres, redis, …) die with:
   ```
   chown: .: Operation not permitted
   ```

A side effect of (1) for nested paths (e.g. `pgdata:/var/lib/postgresql/data`) is that data was being mounted at `/var/lib/postgresql` — the parent — so it wasn't actually persisted at the path the user asked for.

## Fix

`container` 1.0.0 supports named volumes natively and auto-creates them on first `run`. This maps a Compose named volume straight to a `container` named volume named `<project>_<source>` (mirroring Docker Compose's namespacing), mounted at the **declared destination**.

Native volumes are block devices the guest owns, so `chown` works, and the destination is no longer rewritten to its parent. This also retires the now-outdated warning text ("the `container` tool does not support named volume references"), which predates 1.0.0.

## Verification

Against a real `docker-compose.yml` with a `redis` service using `redisdata:/data`:

- **Before:** container crashes on startup — `failed to find target executable docker-entrypoint.sh`.
- **After:** `backend_redisdata` volume is auto-created and redis reaches `Ready to accept connections` / `redis-cli ping` → `PONG`.

## Tests

Adds coverage to `ComposeVolumeTests` (the named-volume branch previously had none):
- maps to a native, project-namespaced volume
- #96 regression: a single-segment destination must not collapse to `/`
- nested destination + mode is preserved
- missing project name is skipped

All 137 static tests pass. (The `.containerDependent` dynamic suites fail in my environment with a pre-existing `No such file or directory` at setup — reproduced identically on a clean `main`, unrelated to this change.)

## Note / out of scope

A postgres service using a named volume will still hit the postgres image's `initdb: directory ... not empty ... lost+found` guard, because `container`'s native volumes are formatted filesystems with a `lost+found`. That's image/platform-specific and is worked around user-side by pointing `PGDATA` at a subdirectory of the mount; it's independent of this fix.