### PR TITLE
fix: preserve user PATH in streamCommand instead of overwriting it

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -786,9 +786,9 @@ extension ComposeUp {
             process.standardOutput = stdoutPipe
             process.standardError = stderrPipe
 
-            process.environment = ProcessInfo.processInfo.environment.merging([
-                "PATH": "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-            ]) { _, new in new }
+            var childEnvironment = ProcessInfo.processInfo.environment
+            childEnvironment["PATH"] = mergedExecutablePath(existing: childEnvironment["PATH"])
+            process.environment = childEnvironment
 
             let stdoutHandle = stdoutPipe.fileHandleForReading
             let stderrHandle = stderrPipe.fileHandleForReading

--- a/Sources/Container-Compose/Helper Functions.swift
+++ b/Sources/Container-Compose/Helper Functions.swift
@@ -33,6 +33,41 @@ public func resolvedPath(for path: String, relativeTo baseURL: URL) -> String {
 }
 
 
+/// The standard executable directories appended as a fallback when building the
+/// PATH for spawned `container` processes.
+public let standardExecutablePathFallback = [
+    "/usr/local/bin", "/opt/homebrew/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin",
+]
+
+/// Builds the PATH used for spawned child processes by preserving the user's
+/// inherited PATH and appending any standard fallback directories that are not
+/// already present. This keeps `container` binaries installed outside the
+/// standard locations (e.g. Nix at `/run/current-system/sw/bin`) reachable while
+/// still guaranteeing the common Homebrew/system directories are available.
+/// - Parameters:
+///   - existing: The inherited PATH value (typically `$PATH`), or `nil` if unset.
+///   - fallback: The standard directories to ensure are present.
+/// - Returns: A `:`-separated PATH string preserving the user's order, followed
+///   by any missing fallback directories.
+public func mergedExecutablePath(
+    existing: String?,
+    fallback: [String] = standardExecutablePathFallback
+) -> String {
+    let existingEntries = (existing ?? "")
+        .split(separator: ":", omittingEmptySubsequences: true)
+        .map(String.init)
+
+    var seen = Set(existingEntries)
+    var merged = existingEntries
+
+    for dir in fallback where !seen.contains(dir) {
+        merged.append(dir)
+        seen.insert(dir)
+    }
+
+    return merged.joined(separator: ":")
+}
+
 /// Loads environment variables from a .env file.
 /// - Parameter path: The full path to the .env file.
 /// - Returns: A dictionary of key-value pairs representing environment variables.

--- a/Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift
+++ b/Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift
@@ -98,6 +98,34 @@ struct HelperFunctionsTests {
         #expect(result == "0.0.0.0:3000:3000")
     }
 
+    @Test("Merged PATH keeps user order and contains all fallback dirs without duplicates")
+    func testMergedPathKeepsOrderNoDuplicates() throws {
+        let existing = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        let result = mergedExecutablePath(existing: existing)
+        #expect(result == existing)
+        for dir in standardExecutablePathFallback {
+            #expect(result.split(separator: ":").filter { $0 == dir }.count == 1)
+        }
+    }
+
+    @Test("Merged PATH preserves a custom user directory")
+    func testMergedPathPreservesCustomDir() throws {
+        let result = mergedExecutablePath(existing: "/run/current-system/sw/bin:/usr/bin")
+        let entries = result.split(separator: ":").map(String.init)
+        #expect(entries.first == "/run/current-system/sw/bin")
+        #expect(entries.contains("/run/current-system/sw/bin"))
+        for dir in standardExecutablePathFallback {
+            #expect(entries.contains(dir))
+        }
+    }
+
+    @Test("Merged PATH falls back to the standard dirs when PATH is empty or unset")
+    func testMergedPathEmptyFallsBack() throws {
+        let expected = standardExecutablePathFallback.joined(separator: ":")
+        #expect(mergedExecutablePath(existing: nil) == expected)
+        #expect(mergedExecutablePath(existing: "") == expected)
+    }
+
 }
 
 /// Trait that creates a unique temporary directory before a test runs and removes it after.


### PR DESCRIPTION
## Summary

`container-compose up` now keeps the user's inherited `PATH` when it spawns `container run`, so installs outside the standard Homebrew/system locations (for example Nix at `/run/current-system/sw/bin/container`) are found instead of failing with `env: container: No such file or directory`.

## Why this matters

In `streamCommand` (Sources/Container-Compose/Commands/ComposeUp.swift), the child `PATH` was built with `ProcessInfo.processInfo.environment.merging(["PATH": "/usr/local/bin:..."]) { _, new in new }`. The `{ _, new in new }` closure replaced the inherited `PATH` with the hardcoded six directories, so any `container` binary outside those dirs was invisible to the streamed `container run` path (issue #111). The fix builds the child `PATH` from the user's existing `PATH` and only appends standard fallback directories that are not already present, preserving custom entries.

## Testing

Added `mergedExecutablePath(existing:fallback:)` as a pure helper in `Sources/Container-Compose/Helper Functions.swift` and covered it with three new cases in `Tests/Container-Compose-StaticTests/HelperFunctionsTests.swift` (user order preserved with no duplicate fallback dirs, a custom `/run/current-system/sw/bin` entry survives, and empty/unset `PATH` falls back to the six standard dirs). Ran `swift build` (succeeds) and `swift test --filter HelperFunctionsTests` (21 tests pass).

Fixes #111
