### PR TITLE
feat: support build.args list form and add `build --build-arg` flag

### DIFF
--- a/Sources/Container-Compose/Codable Structs/Build.swift
+++ b/Sources/Container-Compose/Codable Structs/Build.swift
@@ -42,7 +42,17 @@ public struct Build: Codable, Hashable {
             let keyedContainer = try decoder.container(keyedBy: CodingKeys.self)
             self.context = try keyedContainer.decode(String.self, forKey: .context)
             self.dockerfile = try keyedContainer.decodeIfPresent(String.self, forKey: .dockerfile)
-            self.args = try keyedContainer.decodeIfPresent([String: String].self, forKey: .args)
+            // `args:` accepts both forms per the Compose spec:
+            //   args:                 args:
+            //     KEY: value            - KEY=value
+            // The list form previously threw `typeMismatch` and crashed `up` (#136).
+            if let asMap = try? keyedContainer.decodeIfPresent([String: String].self, forKey: .args) {
+                self.args = asMap
+            } else if let asList = try? keyedContainer.decodeIfPresent([String].self, forKey: .args) {
+                self.args = parseComposeKeyValueList(asList)
+            } else {
+                self.args = nil
+            }
         }
     }
 

--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -369,17 +369,7 @@ public struct Service: Codable, Hashable {
     ///                                   the host doesn't define it, falls
     ///                                   back to an empty string)
     static func parseEnvironmentList(_ entries: [String]) -> [String: String] {
-        var dict: [String: String] = [:]
-        for entry in entries {
-            if let eqIdx = entry.firstIndex(of: "=") {
-                let key = String(entry[..<eqIdx])
-                let value = String(entry[entry.index(after: eqIdx)...])
-                dict[key] = value
-            } else {
-                dict[entry] = ProcessInfo.processInfo.environment[entry] ?? ""
-            }
-        }
-        return dict
+        parseComposeKeyValueList(entries)
     }
 
     /// Returns the services in topological order based on `depends_on` relationships.

--- a/Sources/Container-Compose/Commands/ComposeBuild.swift
+++ b/Sources/Container-Compose/Commands/ComposeBuild.swift
@@ -45,6 +45,12 @@ public struct ComposeBuild: AsyncParsableCommand, @unchecked Sendable {
     @Flag(name: .long, help: "Do not use cache when building")
     var noCache: Bool = false
 
+    @Option(
+        name: .customLong("build-arg"),
+        help: "Set a build-time variable (KEY=VALUE), repeatable. Overrides a matching arg from the compose file. A bare KEY takes its value from the environment."
+    )
+    var buildArgs: [String] = []
+
     @OptionGroup
     var logging: Flags.Logging
 
@@ -91,8 +97,12 @@ public struct ComposeBuild: AsyncParsableCommand, @unchecked Sendable {
         let contextURL = URL(fileURLWithPath: buildConfig.context, relativeTo: URL(fileURLWithPath: composeDirectory))
         var commands = [contextURL.path]
 
-        for (key, value) in buildConfig.args ?? [:] {
-            commands.append(contentsOf: ["--build-arg", "\(key)=\(resolveVariable(value, with: environmentVariables))"])
+        // Compose-file args are interpolated against the env; CLI `--build-arg`
+        // values are passed through as-is (the shell already expanded them) and
+        // win on key conflicts.
+        let fileArgs = (buildConfig.args ?? [:]).mapValues { resolveVariable($0, with: environmentVariables) }
+        for (key, value) in mergedBuildArgs(fileArgs: fileArgs, cliArgs: buildArgs) {
+            commands.append(contentsOf: ["--build-arg", "\(key)=\(value)"])
         }
 
         commands.append(contentsOf: [

--- a/Sources/Container-Compose/Helper Functions.swift
+++ b/Sources/Container-Compose/Helper Functions.swift
@@ -135,6 +135,39 @@ public func resolveVariable(_ value: String, with envVars: [String: String]) -> 
     return resolvedValue
 }
 
+/// Parses the Compose "list form" of `KEY=VALUE` entries — shared by
+/// `environment:` and `build.args:` — into the same `[String: String]` shape the
+/// map form produces. Handles two cases:
+///   - `KEY=value`  → `KEY: value`  (split on the FIRST `=`; later `=` chars stay
+///                                   in the value, so values like
+///                                   `postgres://u:p@h/db?sslmode=require`
+///                                   round-trip correctly)
+///   - `KEY`        → `KEY: <process env value, or "">`  (Compose's
+///                                   "inherit from host" shorthand)
+public func parseComposeKeyValueList(_ entries: [String]) -> [String: String] {
+    var dict: [String: String] = [:]
+    for entry in entries {
+        if let eqIdx = entry.firstIndex(of: "=") {
+            let key = String(entry[..<eqIdx])
+            let value = String(entry[entry.index(after: eqIdx)...])
+            dict[key] = value
+        } else {
+            dict[entry] = ProcessInfo.processInfo.environment[entry] ?? ""
+        }
+    }
+    return dict
+}
+
+/// Merges compose-file `build.args` with CLI `--build-arg` entries. CLI values
+/// take precedence on key conflicts (parity with `docker compose build`).
+/// - Parameters:
+///   - fileArgs: args from the compose file (values already interpolated).
+///   - cliArgs: raw `--build-arg` entries (`KEY=VALUE`, or bare `KEY` inherited
+///              from the environment).
+func mergedBuildArgs(fileArgs: [String: String], cliArgs: [String]) -> [String: String] {
+    fileArgs.merging(parseComposeKeyValueList(cliArgs)) { _, cli in cli }
+}
+
 /// Derives a project name from the current working directory. It replaces any '.' characters with
 /// '_' to ensure compatibility with container naming conventions.
 ///

--- a/Tests/Container-Compose-StaticTests/BuildConfigurationTests.swift
+++ b/Tests/Container-Compose-StaticTests/BuildConfigurationTests.swift
@@ -57,16 +57,72 @@ struct BuildConfigurationTests {
           NODE_VERSION: "18"
           ENV: "production"
         """
-        
+
         let decoder = YAMLDecoder()
         let build = try decoder.decode(Build.self, from: yaml)
-        
+
         #expect(build.context == ".")
         #expect(build.args?["NODE_VERSION"] == "18")
         #expect(build.args?["ENV"] == "production")
     }
+
+    // Compose allows `build.args` in list form (`- KEY=VALUE`), not only the
+    // map form above. Previously the list form threw
+    // `DecodingError.typeMismatch` and crashed the whole `up` (see #136).
+    @Test("Parse build args in list form (KEY=VALUE)")
+    func parseBuildArgsListForm() throws {
+        let yaml = """
+        context: nginx
+        args:
+          - DIR=development
+        """
+
+        let decoder = YAMLDecoder()
+        let build = try decoder.decode(Build.self, from: yaml)
+
+        #expect(build.context == "nginx")
+        #expect(build.args?["DIR"] == "development")
+    }
+
     
-    
+    // Exact repro from #136: a service using the list form of `build.args`
+    // (alongside other fields) used to crash the whole `up` at decode time.
+    @Test("Regression #136: full service with list-form build args decodes")
+    func regressionListFormBuildArgsInService() throws {
+        let yaml = """
+        services:
+          nginx:
+            container_name: proxy
+            build:
+              context: nginx
+              args:
+                - DIR=development
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+        let build = try #require(compose.services["nginx"]??.build)
+
+        #expect(build.context == "nginx")
+        #expect(build.args?["DIR"] == "development")
+    }
+
+    // A build-arg value that itself contains `=` must split on the FIRST `=` only,
+    // so the remainder is preserved verbatim.
+    @Test("List-form build arg value keeps internal '=' characters")
+    func listFormBuildArgValueKeepsEquals() throws {
+        let yaml = """
+        context: .
+        args:
+          - DATABASE_URL=postgres://u:p@h/db?sslmode=require
+        """
+
+        let decoder = YAMLDecoder()
+        let build = try decoder.decode(Build.self, from: yaml)
+
+        #expect(build.args?["DATABASE_URL"] == "postgres://u:p@h/db?sslmode=require")
+    }
+
     @Test("Service with build configuration")
     func serviceWithBuildConfiguration() throws {
         let yaml = """

--- a/Tests/Container-Compose-StaticTests/ComposeBuildParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/ComposeBuildParsingTests.swift
@@ -165,4 +165,28 @@ struct ComposeBuildParsingTests {
         let cmd = try ComposeBuild.parse(["-f", "my-compose.yaml"])
         #expect(cmd.projectOptions.composeFileOptions.composeFilename == "my-compose.yaml")
     }
+
+    @Test("ComposeBuild command accepts repeated --build-arg flags")
+    func composeBuildCommandAcceptsBuildArgFlags() throws {
+        let cmd = try ComposeBuild.parse(["--build-arg", "A=1", "--build-arg", "B=2"])
+        #expect(cmd.buildArgs == ["A=1", "B=2"])
+    }
+
+    @Test("ComposeBuild command defaults build-args to empty")
+    func composeBuildCommandDefaultsBuildArgsToEmpty() throws {
+        let cmd = try ComposeBuild.parse([])
+        #expect(cmd.buildArgs.isEmpty)
+    }
+
+    @Test("CLI --build-arg overrides a matching compose-file arg")
+    func cliBuildArgOverridesFileArg() {
+        let merged = mergedBuildArgs(fileArgs: ["TOKEN": "from-file"], cliArgs: ["TOKEN=from-cli"])
+        #expect(merged["TOKEN"] == "from-cli")
+    }
+
+    @Test("CLI and file build-args that don't collide are both kept")
+    func cliAndFileBuildArgsMerge() {
+        let merged = mergedBuildArgs(fileArgs: ["ENV": "production"], cliArgs: ["TOKEN=abc123"])
+        #expect(merged == ["ENV": "production", "TOKEN": "abc123"])
+    }
 }


### PR DESCRIPTION
## Summary

Completes `build.args` support end-to-end:

- **Fixes #136** — `build.args` in **list form** (`- KEY=VALUE`) threw `DecodingError.typeMismatch: expected Mapping ... found Node` and crashed the entire `up`. `Build` now decodes **both** the map form and the list form.
- **Closes #69** — adds a repeatable **`--build-arg KEY=VALUE`** flag to the `build` subcommand, matching `docker compose build`.

## Details

### #136 — list-form `build.args`
`Build.args` only decoded `[String: String]` (map form), so this valid Compose file crashed at decode time:

```yaml
nginx:
  build:
    context: nginx
    args:
      - DIR=development        # ← list form
```

`Build` now accepts map **or** list, reusing the exact same list-parsing semantics `environment:` already uses. To avoid duplicating that logic, the body of `Service.parseEnvironmentList` is lifted into a shared `parseComposeKeyValueList(_:)` helper that both `environment:` and `build.args:` call — split on the **first** `=` (so values keep internal `=`), and a bare `KEY` inherits from the environment.

### #69 — `build --build-arg`
```
container-compose build --build-arg TOKEN=$TOKEN --build-arg ENV=prod
```
Previously failed with `Unknown option '--build-arg'`. Now, per Docker parity:
- compose-file `args:` values are interpolated against the environment (unchanged),
- CLI `--build-arg` values are passed through as-is and **win on key conflicts**,
- a bare `--build-arg KEY` inherits its value from the environment.

The merge is a small pure function `mergedBuildArgs(fileArgs:cliArgs:)`, unit-tested independently of the daemon.

## Testing (TDD)

Written test-first. Full static suite is green locally:

```
swift test --filter Container_Compose_StaticTests
✔ Test run with 243 tests in 21 suites passed
```

New static tests:
- list-form `build.args` decode + the exact #136 repro at the `DockerCompose` level
- list-form value with an internal `=` (DSN) round-trips
- `--build-arg` flag parsing (repeated + default-empty)
- CLI-overrides-file precedence, and non-colliding CLI+file args both kept

No changes to the dynamic (daemon) tests.

## Scope

`--build-arg` is added only to the `build` subcommand (parity with Docker). `environment:` behavior is unchanged (its existing list-form tests still pass after the shared-helper extraction).
