### PR TITLE
fix: interpolate command and entrypoint environment

### DIFF
--- a/Sources/Container-Compose/Commands/ComposeUp.swift
+++ b/Sources/Container-Compose/Commands/ComposeUp.swift
@@ -361,18 +361,19 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
     /// `-c` flag and the script as a single argument.
     static func entrypointAndCommandArgs(
         entrypoint: [String]?,
-        command: [String]?
+        command: [String]?,
+        environmentVariables: [String: String] = [:]
     ) -> (entrypointFlag: String?, positional: [String]) {
         var positional: [String] = []
         let entrypointFlag: String?
         if let entrypoint, !entrypoint.isEmpty {
-            entrypointFlag = entrypoint.first
-            positional.append(contentsOf: entrypoint.dropFirst())
+            entrypointFlag = entrypoint.first.map { resolveVariable($0, with: environmentVariables) }
+            positional.append(contentsOf: entrypoint.dropFirst().map { resolveVariable($0, with: environmentVariables) })
         } else {
             entrypointFlag = nil
         }
         if let command {
-            positional.append(contentsOf: command)
+            positional.append(contentsOf: command.map { resolveVariable($0, with: environmentVariables) })
         }
         return (entrypointFlag, positional)
     }
@@ -1127,7 +1128,8 @@ public struct ComposeUp: AsyncParsableCommand, @unchecked Sendable {
         // the image. See the helper below for the full mapping.
         let argv = Self.entrypointAndCommandArgs(
             entrypoint: service.entrypoint,
-            command: service.command
+            command: service.command,
+            environmentVariables: environmentVariables
         )
         if let entrypointFlag = argv.entrypointFlag {
             runCommandArgs.append(contentsOf: ["--entrypoint", entrypointFlag])

--- a/Tests/Container-Compose-StaticTests/EntrypointCommandTests.swift
+++ b/Tests/Container-Compose-StaticTests/EntrypointCommandTests.swift
@@ -38,6 +38,39 @@ struct EntrypointCommandTests {
         #expect(r.positional == ["nginx", "-g", "daemon off;"])
     }
 
+    @Test("command arguments interpolate project environment")
+    func commandArgumentsInterpolateProjectEnvironment() {
+        let r = ComposeUp.entrypointAndCommandArgs(
+            entrypoint: nil,
+            command: [
+                "-database=postgres://${CC_TEST_MIGRATE_USER:-compose-user}:${CC_TEST_MIGRATE_PASSWORD:-compose-password}@${CC_TEST_MIGRATE_HOST:-postgres}:5432/app?sslmode=disable",
+                "up",
+            ],
+            environmentVariables: [
+                "CC_TEST_MIGRATE_USER": "env-file-user",
+                "CC_TEST_MIGRATE_PASSWORD": "env-file-password",
+                "CC_TEST_MIGRATE_HOST": "env-file-host",
+            ]
+        )
+
+        #expect(r.positional == [
+            "-database=postgres://env-file-user:env-file-password@env-file-host:5432/app?sslmode=disable",
+            "up",
+        ])
+    }
+
+    @Test("entrypoint arguments interpolate project environment")
+    func entrypointArgumentsInterpolateProjectEnvironment() {
+        let r = ComposeUp.entrypointAndCommandArgs(
+            entrypoint: ["${CC_TEST_MIGRATE_EXECUTABLE}", "${CC_TEST_MIGRATE_FLAG:-default-flag}"],
+            command: ["up"],
+            environmentVariables: ["CC_TEST_MIGRATE_EXECUTABLE": "/usr/local/bin/migrate"]
+        )
+
+        #expect(r.entrypointFlag == "/usr/local/bin/migrate")
+        #expect(r.positional == ["default-flag", "up"])
+    }
+
     @Test("single-element entrypoint, no command → flag set, no positional")
     func singleEntrypointNoCommand() {
         let r = ComposeUp.entrypointAndCommandArgs(


### PR DESCRIPTION
## Summary
- Resolve Compose variables in each list-form command and entrypoint token.
- Use the loaded project environment, preserving process-environment precedence.
- Add command and entrypoint regression coverage.

## Verification
- swift test --filter EntrypointCommandTests (16 tests passed)
- Rebuilt with swift build -c release
- Ran the release binary against the Artifex migration service; the prior literal-variable URL parse failure no longer occurs.