### PR TITLE
fix: make Main the root command instead of a passthrough wrapper

### DIFF
--- a/Sources/ContainerComposeApp/application.swift
+++ b/Sources/ContainerComposeApp/application.swift
@@ -6,13 +6,10 @@
 //
 
 import ContainerComposeCore
-import ArgumentParser
 
 @main
-struct Application: AsyncParsableCommand {
-    @Argument(parsing: .captureForPassthrough) var args: [String]
-    
-    func run() async throws {
-        await Main.main(args)
+struct Application {
+    static func main() async {
+        await Main.main()
     }
 }


### PR DESCRIPTION
The @main Application was itself an AsyncParsableCommand that captured
every argument via .captureForPassthrough and forwarded them to
Main.main(args), so running container-compose went through two nested
ArgumentParser layers.

The outer parser saw all flags first, so --help/-h surfaced the
anonymous wrapper's usage instead of the help configured on Main
(command name, abstract, version, subcommands).

This commit removes the wrapper: Application is now a plain struct
whose static main() calls await Main.main(), making Main — which
already declares the container-compose configuration — the single root
ArgumentParser command.

Fixes #148
