### PR TITLE
feat(build): support build.target for multi-stage Dockerfile builds

### DIFF
--- a/Sources/Container-Compose/Codable Structs/Build.swift
+++ b/Sources/Container-Compose/Codable Structs/Build.swift
@@ -30,7 +30,9 @@ public struct Build: Codable, Hashable {
     public let dockerfile: String?
     /// Build arguments
     public let args: [String: String]?
-    
+    /// Optional target build stage, for multi-stage Dockerfiles
+    public let target: String?
+
     /// Custom initializer to handle `build: .` (string) or `build: { context: . }` (object)
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
@@ -38,15 +40,17 @@ public struct Build: Codable, Hashable {
             self.context = contextString
             self.dockerfile = nil
             self.args = nil
+            self.target = nil
         } else {
             let keyedContainer = try decoder.container(keyedBy: CodingKeys.self)
             self.context = try keyedContainer.decode(String.self, forKey: .context)
             self.dockerfile = try keyedContainer.decodeIfPresent(String.self, forKey: .dockerfile)
             self.args = try keyedContainer.decodeIfPresent([String: String].self, forKey: .args)
+            self.target = try keyedContainer.decodeIfPresent(String.self, forKey: .target)
         }
     }
 
     enum CodingKeys: String, CodingKey {
-        case context, dockerfile, args
+        case context, dockerfile, args, target
     }
 }

--- a/Sources/Container-Compose/Commands/ComposeBuild.swift
+++ b/Sources/Container-Compose/Commands/ComposeBuild.swift
@@ -100,6 +100,10 @@ public struct ComposeBuild: AsyncParsableCommand, @unchecked Sendable {
             "--tag", imageTag,
         ])
 
+        if let target = buildConfig.target, !target.isEmpty {
+            commands.append(contentsOf: ["--target", target])
+        }
+
         if noCache {
             commands.append("--no-cache")
         }

--- a/Tests/Container-Compose-StaticTests/BuildConfigurationTests.swift
+++ b/Tests/Container-Compose-StaticTests/BuildConfigurationTests.swift
@@ -57,16 +57,54 @@ struct BuildConfigurationTests {
           NODE_VERSION: "18"
           ENV: "production"
         """
-        
+
         let decoder = YAMLDecoder()
         let build = try decoder.decode(Build.self, from: yaml)
-        
+
         #expect(build.context == ".")
         #expect(build.args?["NODE_VERSION"] == "18")
         #expect(build.args?["ENV"] == "production")
     }
-    
-    
+
+    @Test("Parse build with target")
+    func parseBuildWithTarget() throws {
+        let yaml = """
+        context: .
+        target: production
+        """
+
+        let decoder = YAMLDecoder()
+        let build = try decoder.decode(Build.self, from: yaml)
+
+        #expect(build.context == ".")
+        #expect(build.target == "production")
+    }
+
+    @Test("Build with no target defaults to nil")
+    func parseBuildWithoutTarget() throws {
+        let yaml = """
+        context: .
+        dockerfile: Dockerfile
+        """
+
+        let decoder = YAMLDecoder()
+        let build = try decoder.decode(Build.self, from: yaml)
+
+        #expect(build.target == nil)
+    }
+
+    @Test("Shorthand build: <context> form has no target")
+    func shorthandBuildHasNoTarget() throws {
+        let yaml = "."
+
+        let decoder = YAMLDecoder()
+        let build = try decoder.decode(Build.self, from: yaml)
+
+        #expect(build.context == ".")
+        #expect(build.target == nil)
+    }
+
+
     @Test("Service with build configuration")
     func serviceWithBuildConfiguration() throws {
         let yaml = """

--- a/Tests/Container-Compose-StaticTests/ComposeBuildParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/ComposeBuildParsingTests.swift
@@ -142,6 +142,37 @@ struct ComposeBuildParsingTests {
         #expect(build.args?["ENV"] == "production")
     }
 
+    @Test("Build target is passed through from compose file")
+    func buildTargetIsPassedThrough() throws {
+        let yaml = """
+        services:
+          app:
+            build:
+              context: .
+              target: production
+        """
+
+        let compose = try YAMLDecoder().decode(DockerCompose.self, from: yaml)
+        let build = try #require(compose.services["app"]??.build)
+
+        #expect(build.target == "production")
+    }
+
+    @Test("Build without target leaves it nil, matching pre-target-support compose files")
+    func buildWithoutTargetIsNil() throws {
+        let yaml = """
+        services:
+          app:
+            build:
+              context: .
+        """
+
+        let compose = try YAMLDecoder().decode(DockerCompose.self, from: yaml)
+        let build = try #require(compose.services["app"]??.build)
+
+        #expect(build.target == nil)
+    }
+
     @Test("ComposeBuild command parses --no-cache flag")
     func composeBuildCommandParsesNoCacheFlag() throws {
         let cmd = try ComposeBuild.parse(["--no-cache"])


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`container build` already exposes `--target <stage>` (confirmed against `container` CLI 1.4.1), but `compose build` never read the Compose `build.target` field, so a multi-stage Dockerfile always built the final stage regardless of what the compose file asked for. This silently produces the wrong image for any compose file that relies on `build.target` to select a non-default stage (e.g. a "runner"/production stage vs. a build stage that has extra tooling like `pnpm`/`npm`).

## What changed

- Added `target: String?` to the `Build` Codable struct, decoded from the object form of `build:` (the shorthand `build: <context>` string form has no target, matching how `dockerfile`/`args` are already handled).
- `ComposeBuild.buildService` now appends `--target <stage>` to the `container build` invocation when `build.target` is set.

## Testing

- Added decode tests for `target` present/absent and for the shorthand string form in `BuildConfigurationTests.swift`.
- Added compose-file-level tests confirming `target` flows through `DockerCompose` decoding in `ComposeBuildParsingTests.swift`.
- `swift test --filter Container_Compose_StaticTests` — 260 tests, all passing.

## Code of Conduct

- [x] I agree to follow this project's Code of Conduct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Acfz2Ak1icSW7meh7L2DpW