### PR TITLE
fix(service): word-split string-form command/entrypoint per Compose spec

### DIFF
--- a/Sources/Container-Compose/Codable Structs/Service.swift
+++ b/Sources/Container-Compose/Codable Structs/Service.swift
@@ -264,11 +264,14 @@ public struct Service: Codable, Hashable {
 
         ports = try container.decodeIfPresent([String].self, forKey: .ports)
 
-        // Decode 'command' which can be either a single string or an array of strings.
+        // Decode 'command' which can be either a single string or an array of
+        // strings. Per the Compose spec, the string form is shorthand for the
+        // equivalent word-split list — not a single argv entry — so it's tokenized
+        // with ShellWords rather than kept as one element (see ShellWords.swift).
         if let cmdArray = try? container.decodeIfPresent([String].self, forKey: .command) {
             command = cmdArray
         } else if let cmdString = try? container.decodeIfPresent(String.self, forKey: .command) {
-            command = [cmdString]
+            command = ShellWords.split(cmdString)
         } else {
             command = nil
         }
@@ -304,11 +307,12 @@ public struct Service: Codable, Hashable {
         }
         hostname = try container.decodeIfPresent(String.self, forKey: .hostname)
         
-        // Decode 'entrypoint' which can be either a single string or an array of strings.
+        // Decode 'entrypoint' which can be either a single string or an array of
+        // strings; the string form is word-split the same way as 'command' above.
         if let entrypointArray = try? container.decodeIfPresent([String].self, forKey: .entrypoint) {
             entrypoint = entrypointArray
         } else if let entrypointString = try? container.decodeIfPresent(String.self, forKey: .entrypoint) {
-            entrypoint = [entrypointString]
+            entrypoint = ShellWords.split(entrypointString)
         } else {
             entrypoint = nil
         }

--- a/Sources/Container-Compose/ShellWords.swift
+++ b/Sources/Container-Compose/ShellWords.swift
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Splits a Compose `command:`/`entrypoint:` string value into argv-style words.
+///
+/// Per the Compose spec, the string form of `command`/`entrypoint` is shorthand
+/// for the equivalent list form — `command: bundle exec thin -p 3000` means the
+/// same thing as `command: ["bundle", "exec", "thin", "-p", "3000"]` — not a
+/// `/bin/sh -c "<string>"` wrapper. Decoding a bare string into a single-element
+/// array (the previous behavior here) instead passes the whole string as one
+/// argv entry to `container run`, so callers relying on the documented
+/// string-form shorthand (e.g. `command: sh -c "foo && bar"`, expecting argv
+/// `["sh", "-c", "foo && bar"]`) would see it break.
+public enum ShellWords {
+    /// Tokenizes `input` using POSIX-ish shell word-splitting: unquoted
+    /// whitespace separates words, single quotes preserve their contents
+    /// literally, double quotes preserve their contents except for `\"`, `\\`,
+    /// `\$`, and `` \` `` (which drop the backslash), and a backslash outside
+    /// any quotes escapes the following character. This mirrors the tokenizer
+    /// Docker Compose itself uses for the string form of `command`/`entrypoint`
+    /// (no globbing, variable expansion, or command substitution — those don't
+    /// apply here since the result is passed directly as argv, never run
+    /// through an actual shell).
+    public static func split(_ input: String) -> [String] {
+        var words: [String] = []
+        var current = ""
+        var hasCurrent = false
+
+        enum Quote {
+            case none, single, double
+        }
+        var quote: Quote = .none
+
+        var iterator = input.makeIterator()
+        while let char = iterator.next() {
+            switch quote {
+            case .none:
+                switch char {
+                case " ", "\t", "\n", "\r":
+                    if hasCurrent {
+                        words.append(current)
+                        current = ""
+                        hasCurrent = false
+                    }
+                case "'":
+                    quote = .single
+                    hasCurrent = true
+                case "\"":
+                    quote = .double
+                    hasCurrent = true
+                case "\\":
+                    if let escaped = iterator.next() {
+                        current.append(escaped)
+                        hasCurrent = true
+                    }
+                default:
+                    current.append(char)
+                    hasCurrent = true
+                }
+            case .single:
+                if char == "'" {
+                    quote = .none
+                } else {
+                    current.append(char)
+                }
+            case .double:
+                if char == "\"" {
+                    quote = .none
+                } else if char == "\\" {
+                    if let escaped = iterator.next() {
+                        if "\"\\$`".contains(escaped) {
+                            current.append(escaped)
+                        } else {
+                            current.append(char)
+                            current.append(escaped)
+                        }
+                    } else {
+                        current.append(char)
+                    }
+                } else {
+                    current.append(char)
+                }
+            }
+        }
+
+        if hasCurrent {
+            words.append(current)
+        }
+
+        return words
+    }
+}

--- a/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
+++ b/Tests/Container-Compose-StaticTests/DockerComposeParsingTests.swift
@@ -267,7 +267,7 @@ struct DockerComposeParsingTests {
         #expect(compose.services["app"]??.command?.first == "sh")
     }
     
-    @Test("Parse compose with command as string")
+    @Test("Parse compose with command as string — word-split per Compose spec shorthand")
     func parseComposeWithCommandString() throws {
         let yaml = """
         version: '3.8'
@@ -276,12 +276,46 @@ struct DockerComposeParsingTests {
             image: alpine:latest
             command: "echo hello"
         """
-        
+
         let decoder = YAMLDecoder()
         let compose = try decoder.decode(DockerCompose.self, from: yaml)
-        
-        #expect(compose.services["app"]??.command?.count == 1)
-        #expect(compose.services["app"]??.command?.first == "echo hello")
+
+        // Per the Compose spec, `command: echo hello` is shorthand for
+        // `command: ["echo", "hello"]` — not a single opaque argv entry.
+        #expect(compose.services["app"]??.command?.count == 2)
+        #expect(compose.services["app"]??.command == ["echo", "hello"])
+    }
+
+    @Test("Parse compose with command as string containing a quoted argument")
+    func parseComposeWithCommandStringQuoted() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: alpine:latest
+            command: "sh -c 'echo hello world'"
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+
+        #expect(compose.services["app"]??.command == ["sh", "-c", "echo hello world"])
+    }
+
+    @Test("Parse compose with entrypoint as string — word-split per Compose spec shorthand")
+    func parseComposeWithEntrypointString() throws {
+        let yaml = """
+        version: '3.8'
+        services:
+          app:
+            image: alpine:latest
+            entrypoint: "/code/entrypoint.sh --verbose"
+        """
+
+        let decoder = YAMLDecoder()
+        let compose = try decoder.decode(DockerCompose.self, from: yaml)
+
+        #expect(compose.services["app"]??.entrypoint == ["/code/entrypoint.sh", "--verbose"])
     }
     
     @Test("Parse compose with restart policy")

--- a/Tests/Container-Compose-StaticTests/ShellWordsTests.swift
+++ b/Tests/Container-Compose-StaticTests/ShellWordsTests.swift
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Morris Richman and the Container-Compose project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+@testable import ContainerComposeCore
+
+@Suite("ShellWords Tests")
+struct ShellWordsTests {
+
+    @Test("Splits plain whitespace-separated words")
+    func splitsPlainWords() {
+        #expect(ShellWords.split("bundle exec thin -p 3000") == ["bundle", "exec", "thin", "-p", "3000"])
+    }
+
+    @Test("Collapses runs of whitespace between words")
+    func collapsesRepeatedWhitespace() {
+        #expect(ShellWords.split("echo   hello\tworld") == ["echo", "hello", "world"])
+    }
+
+    @Test("Empty string produces no words")
+    func emptyStringProducesNoWords() {
+        #expect(ShellWords.split("") == [])
+    }
+
+    @Test("Whitespace-only string produces no words")
+    func whitespaceOnlyProducesNoWords() {
+        #expect(ShellWords.split("   \t  ") == [])
+    }
+
+    @Test("Single word with no whitespace")
+    func singleWord() {
+        #expect(ShellWords.split("nginx") == ["nginx"])
+    }
+
+    @Test("Double-quoted argument preserves internal spaces as one word")
+    func doubleQuotedArgumentPreservesSpaces() {
+        #expect(ShellWords.split(#"sh -c "echo hello world""#) == ["sh", "-c", "echo hello world"])
+    }
+
+    @Test("Single-quoted argument preserves internal spaces as one word")
+    func singleQuotedArgumentPreservesSpaces() {
+        #expect(ShellWords.split("sh -c 'echo hello world'") == ["sh", "-c", "echo hello world"])
+    }
+
+    @Test("Single quotes treat backslashes literally")
+    func singleQuotesAreLiteral() {
+        #expect(ShellWords.split(#"echo 'a\b'"#) == ["echo", #"a\b"#])
+    }
+
+    @Test("Double quotes unescape \\\" and \\\\ but leave other backslashes alone")
+    func doubleQuotesUnescapeOnlySpecialChars() {
+        #expect(ShellWords.split(#"echo "say \"hi\" \\ done""#) == ["echo", #"say "hi" \ done"#])
+        #expect(ShellWords.split(#"echo "C:\path\to\file""#) == ["echo", #"C:\path\to\file"#])
+    }
+
+    @Test("Backslash outside quotes escapes the next character, including a space")
+    func backslashOutsideQuotesEscapesNextChar() {
+        #expect(ShellWords.split(#"echo hello\ world"#) == ["echo", "hello world"])
+    }
+
+    @Test("Adjacent quoted and unquoted segments join into a single word")
+    func adjacentQuotedAndUnquotedSegmentsJoin() {
+        #expect(ShellWords.split(#"echo foo"bar baz"qux"#) == ["echo", "foobar bazqux"])
+    }
+
+    @Test("Empty quotes produce an empty-string word")
+    func emptyQuotesProduceEmptyWord() {
+        #expect(ShellWords.split(#"cmd -e "" next"#) == ["cmd", "-e", "", "next"])
+    }
+
+    @Test("Compose spec example: string form matches its documented list-form equivalent")
+    func composeSpecStringFormMatchesListForm() {
+        // From the Compose spec: `command: bundle exec thin -p 3000` is
+        // documented as equivalent to `["bundle", "exec", "thin", "-p", "3000"]`.
+        #expect(ShellWords.split("bundle exec thin -p 3000") == ["bundle", "exec", "thin", "-p", "3000"])
+    }
+
+    @Test("Realistic multi-flag shell invocation")
+    func realisticShellInvocation() {
+        #expect(
+            ShellWords.split(#"sh -c "sed -i 's/Listen 80/Listen 8080/' /etc/httpd.conf && exec httpd-foreground""#)
+                == ["sh", "-c", "sed -i 's/Listen 80/Listen 8080/' /etc/httpd.conf && exec httpd-foreground"]
+        )
+    }
+}


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

## Motivation and Context

Per the [Compose spec](https://github.com/compose-spec/compose-spec/blob/master/05-services.md#command), the string form of `command`/`entrypoint` is documented shorthand for the equivalent word-split list — e.g. `command: bundle exec thin -p 3000` is defined as equivalent to `command: ["bundle", "exec", "thin", "-p", "3000"]`. Today, decoding a bare string produces a **single-element array** (`["bundle exec thin -p 3000"]`) instead, so the whole string is passed to `container run` as one argv entry.

This breaks the common `command: sh -c "foo && bar"` pattern: the container's entrypoint receives `sh -c "foo && bar"` as a single argument instead of the three arguments `sh`, `-c`, `foo && bar` — so the shell never actually runs, and the command fails or does nothing.

## What changed

- Added `ShellWords.swift`: a small, dependency-free POSIX-ish tokenizer (whitespace splitting, single/double quote handling, backslash escapes) matching the word-splitting Compose documents for this shorthand. It doesn't do variable expansion or command substitution — the result is only ever used as argv, never actually run through a shell.
- `Service.swift` now uses `ShellWords.split(...)` instead of `[str]` when decoding the string form of both `command` and `entrypoint`.

## Compatibility note

I flagged this as a breaking change because it changes existing (non-conforming) behavior: any compose file currently relying on the single-arg passthrough — if such a case exists — would see different argv after this change. I don't believe there's a valid use case that depends on the old behavior (a single opaque string being passed to `container run` as one argument isn't something Docker Compose itself does), but wanted to be upfront about the change in observable behavior rather than call it a pure bug fix.

## Testing

- New `ShellWordsTests.swift`: 13 tests covering plain splitting, whitespace collapsing, single/double quoting, backslash escapes (in and outside quotes), adjacent quoted/unquoted segments, empty quoted args, and the Compose spec's own documented example.
- Updated the existing `DockerComposeParsingTests.swift` "command as string" test to reflect the corrected (spec-conforming) output, and added new tests for a quoted-argument string command and a string-form `entrypoint`.
- `swift test --filter Container_Compose_StaticTests` — 260 tests, all passing (no other suite assumed the old single-arg behavior).

## Code of Conduct

- [x] I agree to follow this project's Code of Conduct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Acfz2Ak1icSW7meh7L2DpW